### PR TITLE
Unblock csharp-expert agent for Story 1

### DIFF
--- a/hooks/bash-expert-validation.json
+++ b/hooks/bash-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "bash-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Quality gates and validation standards for Bash/shell script development",
   "priority": "medium",
+  "enabled": true,
   "agents": [
     "bash-expert",
     "code-review-gatekeeper",
@@ -13,6 +14,22 @@
     "sh_file_save",
     "pre_commit"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify there are Bash/shell scripts before running validation",
+      "detection_methods": [
+        {
+          "method": "check_bash_files",
+          "command": "find . -maxdepth 3 \\( -name '*.sh' -o -name '*.bash' \\) 2>/dev/null | head -1",
+          "required": true,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping Bash validation: No Bash scripts detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_syntax_validation": {
       "description": "Bash syntax and compatibility checks",

--- a/hooks/csharp-expert-validation.json
+++ b/hooks/csharp-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "csharp-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive quality gates and validation standards for C#/.NET development",
   "priority": "high",
+  "enabled": true,
   "agents": [
     "csharp-expert",
     "code-review-gatekeeper",
@@ -16,6 +17,28 @@
     "csharp_file_save",
     "nuget_package_update"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify this is a C#/.NET project before running validation",
+      "detection_methods": [
+        {
+          "method": "search_csproj_files",
+          "command": "find . -maxdepth 3 -name '*.csproj' -o -name '*.sln' 2>/dev/null",
+          "required": true,
+          "skip_validation_if_not_found": true
+        },
+        {
+          "method": "check_cs_files",
+          "command": "find . -maxdepth 3 -name '*.cs' 2>/dev/null | head -1",
+          "required": false,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping C# validation: No C#/.NET project detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_compilation": {
       "description": ".NET compilation and build verification",

--- a/hooks/go-expert-validation.json
+++ b/hooks/go-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "go-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive quality gates and validation standards for Go development",
   "priority": "high",
+  "enabled": true,
   "agents": [
     "go-expert",
     "code-review-gatekeeper",
@@ -16,6 +17,28 @@
     "go_file_save",
     "dependency_update"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify this is a Go project before running validation",
+      "detection_methods": [
+        {
+          "method": "search_go_mod",
+          "command": "find . -maxdepth 3 \\( -name 'go.mod' -o -name 'go.sum' \\) 2>/dev/null",
+          "required": true,
+          "skip_validation_if_not_found": true
+        },
+        {
+          "method": "check_go_files",
+          "command": "find . -maxdepth 3 -name '*.go' 2>/dev/null | head -1",
+          "required": false,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping Go validation: No Go project detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_compilation": {
       "description": "Go compilation and build verification",

--- a/hooks/powershell-expert-validation.json
+++ b/hooks/powershell-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "powershell-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Quality gates and validation standards for PowerShell development",
   "priority": "medium",
+  "enabled": true,
   "agents": [
     "powershell-expert",
     "code-review-gatekeeper",
@@ -14,6 +15,22 @@
     "psm1_file_save",
     "pre_commit"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify there are PowerShell scripts before running validation",
+      "detection_methods": [
+        {
+          "method": "check_powershell_files",
+          "command": "find . -maxdepth 3 \\( -name '*.ps1' -o -name '*.psm1' -o -name '*.psd1' \\) 2>/dev/null | head -1",
+          "required": true,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping PowerShell validation: No PowerShell scripts detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_syntax_validation": {
       "description": "PowerShell syntax and parsing",

--- a/hooks/python-expert-validation.json
+++ b/hooks/python-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "python-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive quality gates and validation standards for Python development",
   "priority": "high",
+  "enabled": true,
   "agents": [
     "python-expert",
     "code-review-gatekeeper",
@@ -16,6 +17,28 @@
     "python_file_save",
     "poetry_lock_update"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify this is a Python project before running validation",
+      "detection_methods": [
+        {
+          "method": "search_python_config",
+          "command": "find . -maxdepth 3 \\( -name 'requirements.txt' -o -name 'pyproject.toml' -o -name 'setup.py' -o -name 'Pipfile' \\) 2>/dev/null",
+          "required": true,
+          "skip_validation_if_not_found": true
+        },
+        {
+          "method": "check_python_files",
+          "command": "find . -maxdepth 3 -name '*.py' 2>/dev/null | head -1",
+          "required": false,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping Python validation: No Python project detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_syntax_import": {
       "description": "Python syntax and import verification",

--- a/hooks/rust-expert-validation.json
+++ b/hooks/rust-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "rust-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive quality gates and validation standards for Rust development",
   "priority": "high",
+  "enabled": true,
   "agents": [
     "rust-expert",
     "code-review-gatekeeper",
@@ -16,6 +17,28 @@
     "rust_file_save",
     "dependency_update"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify this is a Rust project before running validation",
+      "detection_methods": [
+        {
+          "method": "search_cargo_files",
+          "command": "find . -maxdepth 3 -name 'Cargo.toml' 2>/dev/null",
+          "required": true,
+          "skip_validation_if_not_found": true
+        },
+        {
+          "method": "check_rust_files",
+          "command": "find . -maxdepth 3 -name '*.rs' 2>/dev/null | head -1",
+          "required": false,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping Rust validation: No Rust project detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_compilation": {
       "description": "Rust compilation and build verification",

--- a/hooks/typescript-expert-validation.json
+++ b/hooks/typescript-expert-validation.json
@@ -1,8 +1,9 @@
 {
   "name": "typescript-expert-validation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive quality gates and validation standards for TypeScript/JavaScript development",
   "priority": "high",
+  "enabled": true,
   "agents": [
     "typescript-expert",
     "code-review-gatekeeper",
@@ -17,6 +18,28 @@
     "pre_commit",
     "ts_js_file_save"
   ],
+  "prerequisite_checks": {
+    "project_detection": {
+      "enabled": true,
+      "blocking": true,
+      "description": "Verify this is a TypeScript/JavaScript project before running validation",
+      "detection_methods": [
+        {
+          "method": "search_package_json",
+          "command": "find . -maxdepth 3 -name 'package.json' -o -name 'tsconfig.json' 2>/dev/null",
+          "required": true,
+          "skip_validation_if_not_found": true
+        },
+        {
+          "method": "check_ts_js_files",
+          "command": "find . -maxdepth 3 \\( -name '*.ts' -o -name '*.js' -o -name '*.tsx' -o -name '*.jsx' \\) 2>/dev/null | head -1",
+          "required": false,
+          "skip_validation_if_not_found": true
+        }
+      ],
+      "skip_message": "⏭️ Skipping TypeScript/JavaScript validation: No TS/JS project detected in workspace"
+    }
+  },
   "validation_sequence": {
     "phase_1_compilation": {
       "description": "TypeScript compilation and JavaScript syntax",


### PR DESCRIPTION
Resolves blocking issue where validation hooks would run regardless of project type, causing validation failures in non-matching workspaces.

Changes:
- Add prerequisite_checks with project detection to 7 validation hooks
- Each hook now verifies project type before running validation
- If no matching project found, validation is skipped with clear message

Affected hooks:
- csharp-expert-validation.json (v1.0.0 → v1.0.1)
- rust-expert-validation.json (v1.0.0 → v1.0.1)
- typescript-expert-validation.json (v1.0.0 → v1.0.1)
- python-expert-validation.json (v1.0.0 → v1.0.1)
- go-expert-validation.json (v1.0.0 → v1.0.1)
- bash-expert-validation.json (v1.0.0 → v1.0.1)
- powershell-expert-validation.json (v1.0.0 → v1.0.1)

Detection methods:
- C#: Search for *.csproj, *.sln, *.cs files
- Rust: Search for Cargo.toml, *.rs files
- TypeScript/JS: Search for package.json, tsconfig.json, *.ts/js files
- Python: Search for requirements.txt, pyproject.toml, setup.py, *.py files
- Go: Search for go.mod, go.sum, *.go files
- Bash: Search for *.sh, *.bash files
- PowerShell: Search for *.ps1, *.psm1, *.psd1 files

This fix ensures agents can execute without being blocked by irrelevant validation checks when working outside their target project types.