### PR TITLE
fix: Update Homebrew installation command for Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This framework **extends Claude Code CLI** with specialized agents, automated le
 **macOS:**
 ```bash
 # Using Homebrew
-brew install claude-cli
+brew install --cask claude-code
 
 # Verify installation
 claude --version


### PR DESCRIPTION
### Merge Request: Update Homebrew Installation Instructions

**Summary:**
This merge request addresses an issue in the README regarding the installation instructions for the Claude Code CLI. The previous instructions incorrectly referenced the Homebrew formula for `claude-cli`, which does not exist. This has been corrected to use the appropriate command for installation.

**Changes Made:**
- Updated the macOS installation instructions to reflect the correct command: `brew install --cask claude-code`.

**Related Issue:**
- fix #10 

**Testing:**
- Verified that the new command works as expected and successfully installs the application.

<img width="1412" height="438" alt="image" src="https://github.com/user-attachments/assets/bd66c08e-26fe-4c7d-81df-bc4177c6bc48" />
