### PR TITLE
feat: anti-drift consistency system (dynamic validator + doc generator + CI)

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Least privilege: these scripts only read the checked-out tree and need no
+# write access to repo contents, issues, PRs, or any other scope.
+permissions:
+  contents: read
+
 jobs:
   consistency:
     name: validate + generate-check + tests
@@ -18,12 +23,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure jq is available
+        # jq ships preinstalled on ubuntu-latest; fail fast (no apt-get) if it
+        # is somehow missing rather than silently masking an unexpected image.
         run: |
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq not found; installing..."
-            sudo apt-get update && sudo apt-get install -y jq
-          fi
-          echo "jq version: $(jq --version)"
+          command -v jq >/dev/null || { echo "jq missing"; exit 1; }
+          jq --version
 
       - name: Validate consistency (dynamic anti-drift checks)
         run: bash scripts/validate-consistency.sh

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -1,0 +1,35 @@
+name: consistency
+
+# Run the anti-drift consistency gate on every PR and on pushes to the
+# default branch. The generate-docs.sh --check step is what fails the build
+# when committed GENERATED blocks have drifted from claude.json.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  consistency:
+    name: validate + generate-check + tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure jq is available
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq not found; installing..."
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          echo "jq version: $(jq --version)"
+
+      - name: Validate consistency (dynamic anti-drift checks)
+        run: bash scripts/validate-consistency.sh
+
+      - name: Check generated docs are fresh
+        run: bash scripts/generate-docs.sh --check
+
+      - name: Run consistency test harness
+        run: bash tests/consistency.test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/CLAUDE.md
 !/.gitignore
 !/README.md
+!/CONTRIBUTING.md
 !/.env.example
 !/SECURITY_AUDIT.md
 !/security-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 !/shared/
 !/skills/
 !/scripts/
+!/tests/
+!/.github/
 
 # Explicitly ignore files at the root that should not be tracked
 /settings.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,10 @@ This runs 11 checks including:
 - Registry ↔ filesystem parity
 - Category partition (no duplicates, no gaps)
 - Hook coverage (every non-allowlisted agent has a validation hook)
-- JSON validity
+- JSON validity (and best-effort YAML — skipped locally when no python/ruby YAML parser is present; runs on CI)
 - No use of deprecated names
 - Architecture description count accuracy
-- Model parity (agents/<name>.md frontmatter matches claude.json) — WARNING only
+- Model parity (agents/<name>.md frontmatter vs claude.json) — advisory WARNING only (see note below)
 - Roster presence in prose tables (README, CLAUDE.md, list-agents.md)
 - README focus-text parity (README Focus cells match claude.json .focus fields)
 - Generated blocks are fresh
@@ -111,7 +111,7 @@ The validator will tell you exactly which tables need updates. Do not hardcode a
 - **Derives all truth at runtime** from `claude.json` and the filesystem — no hardcoded lists
 - **Runs 11 checks** (see summary above) and collects all failures before exiting
 - **Distinguishes blocking vs. advisory**: exits non-zero on any blocking check failure
-- **Model parity is WARNING only** (check 7) — frontmatter model mismatches do not block CI
+- **Model parity is advisory only** (check 7) — it does not block CI. The frontmatter `model:` and claude.json's per-agent model currently diverge for several agents (most `.md` files declare `opus`); mismatches are reported for awareness, not enforced. Reconciling them — and deciding which is authoritative for runtime — is deferred to a separate model-alignment change.
 
 Run it during development and before pushing. CI (`.github/workflows/consistency.yml`) runs it on every PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,157 @@
+# Contributing to the Claude Code CLI Agent Framework
+
+This guide explains the anti-drift consistency system and how to contribute to the framework while maintaining data integrity.
+
+## Single Source of Truth
+
+`claude.json` is the canonical registry for the entire framework. It contains:
+
+- **`.sub_agents`** — the roster, including each agent's model, specialization, and `focus` field
+- **`.agent_categories`** — taxonomy that partitions agents into exactly one category group
+- **`.consistency`** — metadata controlling generator and validator behavior:
+  - `hook_coverage_allowlist` — agents exempt from requiring a per-agent `{agent}-validation.json` hook
+  - `deprecated_agent_names` — retired agent identifiers (flagged if re-used)
+  - `model_shorthand_map` — e.g., `"opus" -> "claude-opus-4-6-20250805"`
+  - `doc_blocks` — registry of machine-generated documentation regions
+
+Do not hand-edit agent counts, rosters, or model assignments in documentation or scripts — they are derived from `claude.json` and the filesystem at validation time.
+
+## Adding or Changing an Agent
+
+Follow these steps in order:
+
+### 1. Create the agent prompt file
+
+Add `agents/<name>.md` with YAML frontmatter:
+
+```yaml
+---
+name: <agent-name>
+description: <one-paragraph summary + examples>
+model: <shorthand-key or full id>  # e.g., "opus" or "claude-opus-4-6-20250805"
+color: <color-name>
+---
+
+## Core Expertise
+...
+```
+
+### 2. Register in `claude.json`
+
+In the `.sub_agents` object, add an entry with `model` and `focus`:
+
+```json
+"your-agent": {
+  "enabled": true,
+  "path": "~/.claude/agents/your-agent",
+  "config_file": "~/.claude/agents/your-agent/agent.json",
+  "prompt_file": "~/.claude/agents/your-agent.md",
+  "model": "claude-sonnet-4-6-20250514",
+  "specialization": "your_domain_area",
+  "focus": "Brief focus area (1-2 sentences)"
+}
+```
+
+Also add the agent to exactly one group in `.agent_categories`.
+
+### 3. Create the validation hook (or allowlist the agent)
+
+One of two approaches:
+
+**Option A (standard):** Create `hooks/<agent>-validation.json` with quality gates and test requirements (see `hooks/rust-expert-validation.json` for a complete example).
+
+**Option B (framework-wide gate):** If the agent shares validation with a framework-wide hook (e.g., all agents are gated by `peer-review-critic`), add the agent to `claude.json .consistency.hook_coverage_allowlist`:
+
+```json
+"consistency": {
+  "hook_coverage_allowlist": ["peer-review-critic", "your-agent"]
+}
+```
+
+### 4. Refresh generated documentation
+
+Run the generator to update any `<!-- BEGIN GENERATED: ... -->` marker regions:
+
+```bash
+bash scripts/generate-docs.sh --write
+```
+
+### 5. Validate the change
+
+Run the full consistency check:
+
+```bash
+bash scripts/validate-consistency.sh
+```
+
+This runs 11 checks including:
+- Registry ↔ filesystem parity
+- Category partition (no duplicates, no gaps)
+- Hook coverage (every non-allowlisted agent has a validation hook)
+- JSON validity
+- No use of deprecated names
+- Architecture description count accuracy
+- Model parity (agents/<name>.md frontmatter matches claude.json) — WARNING only
+- Roster presence in prose tables (README, CLAUDE.md, list-agents.md)
+- README focus-text parity (README Focus cells match claude.json .focus fields)
+- Generated blocks are fresh
+
+All blocking checks must pass (exit 0).
+
+### 6. Update prose tables
+
+If the validator reports roster-presence failures in `README.md` or `CLAUDE.md` tables, add the agent row to those hand-written tables. Consult the tables' existing structure for style.
+
+The validator will tell you exactly which tables need updates. Do not hardcode any counts in these tables — omit agent/hook counts and use phrases like "the current roster in claude.json" if needed.
+
+## The Validator
+
+`bash scripts/validate-consistency.sh` is the primary integrity gate. It:
+
+- **Derives all truth at runtime** from `claude.json` and the filesystem — no hardcoded lists
+- **Runs 11 checks** (see summary above) and collects all failures before exiting
+- **Distinguishes blocking vs. advisory**: exits non-zero on any blocking check failure
+- **Model parity is WARNING only** (check 7) — frontmatter model mismatches do not block CI
+
+Run it during development and before pushing. CI (`.github/workflows/consistency.yml`) runs it on every PR.
+
+## The Generator
+
+`bash scripts/generate-docs.sh` is a documentation-freshness gate. It:
+
+- **Modes:**
+  - `--write`: regenerate all `<!-- BEGIN GENERATED: ... -->` marker regions from claude.json + facts
+  - `--check`: verify regions are up to date; fails if any are stale
+- **Machine-owned regions**: do not hand-edit content between the markers (the validator enforces freshness)
+- **Coverage:** currently generates the `commands/list-agents.md` JSON summary block. Prose tables (README "## Agents", CLAUDE.md roster, list-agents.md textual categories) are hand-written and guarded by roster-presence checks instead (better structural flexibility).
+
+Always run `--write` after editing `claude.json`, then validate.
+
+## CI / Continuous Integration
+
+The workflow `.github/workflows/consistency.yml` runs on every PR and push to main:
+
+```bash
+bash scripts/validate-consistency.sh       # runs 11 checks
+bash scripts/generate-docs.sh --check      # fails if generated blocks are stale
+bash tests/consistency.test.sh             # 10-case test harness
+```
+
+To reproduce a CI failure locally, run these three commands from the repo root. All must exit 0.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Add/update an agent | Follow the 6-step process above |
+| Regenerate docs | `bash scripts/generate-docs.sh --write` |
+| Validate everything | `bash scripts/validate-consistency.sh && echo exit=$?` |
+| Check freshness (CI mode) | `bash scripts/generate-docs.sh --check && echo exit=$?` |
+| Run all tests | `bash tests/consistency.test.sh && echo exit=$?` |
+
+## Notes
+
+- The framework operates on **LF line endings** (configured in `.gitattributes eol=lf`). Do not commit CRLF.
+- `FRAMEWORK_ROOT` environment variable overrides git discovery if set; useful for testing against isolated copies.
+- Never suppress hooks with `--no-verify` unless troubleshooting a hook failure. Hook violations indicate real inconsistencies.
+- Questions? See the validator output — it names every failure precisely.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ Tasks are automatically routed to the appropriate agent. Examples:
 ├── hooks/                   # 45 quality gates (agent-specific + framework-wide)
 ├── shared/                  # Shared configs (base-config, mcp-config, agent-patterns, memory-categories)
 ├── skills/                  # 14 operational skills (validation, debugging, analytics, scaffolding)
-├── scripts/                 # 3 validation scripts
+├── scripts/                 # Validation, anti-drift consistency, and doc-generation scripts
+├── tests/                   # Consistency test harness
+├── .github/workflows/       # CI (anti-drift consistency gate)
 └── security-check.sh        # Security validation
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ cat commands/delegate.md | head -20  # Verify command exists
 
 ---
 
+## Contributing
+
+To add or modify agents, manage framework consistency, or understand the anti-drift validation system, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 ## Resources
 
 - [Claude Code CLI Documentation](https://docs.claude.com/en/docs/claude-code)

--- a/claude.json
+++ b/claude.json
@@ -2,6 +2,16 @@
   "version": "3.0.0",
   "description": "Claude Code CLI with 20-agent specialized architecture",
 
+  "consistency": {
+    "hook_coverage_allowlist": ["peer-review-critic"],
+    "deprecated_agent_names": ["maker", "maker-agent", "test-agent", "debug-agent", "reader-agent", "plan-agent", "rust-systems-expert"],
+    "model_shorthand_map": {
+      "opus": "claude-opus-4-6-20250805",
+      "sonnet": "claude-sonnet-4-6-20250514",
+      "haiku": "claude-haiku-4-5-20251001"
+    }
+  },
+
   "sub_agents": {
     "rust-expert": {
       "enabled": true,

--- a/claude.json
+++ b/claude.json
@@ -9,6 +9,16 @@
       "opus": "claude-opus-4-6-20250805",
       "sonnet": "claude-sonnet-4-6-20250514",
       "haiku": "claude-haiku-4-5-20251001"
+    },
+    "doc_blocks": {
+      "list_agents_summary_categories": {
+        "language_experts": ["language_experts", "automation_experts"],
+        "domain_specialists": ["domain_specialists"],
+        "infrastructure": ["infrastructure_operations"],
+        "architecture_planning": ["architecture_planning"],
+        "quality_analysis": ["quality_analysis"],
+        "documentation": ["documentation"]
+      }
     }
   },
 
@@ -19,7 +29,8 @@
       "config_file": "~/.claude/agents/rust-expert/agent.json",
       "prompt_file": "~/.claude/agents/rust-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "rust_development_systems_programming"
+      "specialization": "rust_development_systems_programming",
+      "focus": "Systems programming, memory safety, async/await"
     },
     "csharp-expert": {
       "enabled": true,
@@ -27,7 +38,8 @@
       "config_file": "~/.claude/agents/csharp-expert/agent.json",
       "prompt_file": "~/.claude/agents/csharp-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "csharp_dotnet_azure_development"
+      "specialization": "csharp_dotnet_azure_development",
+      "focus": "ASP.NET Core, Entity Framework, Azure"
     },
     "go-expert": {
       "enabled": true,
@@ -35,7 +47,8 @@
       "config_file": "~/.claude/agents/go-expert/agent.json",
       "prompt_file": "~/.claude/agents/go-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "go_microservices_cloud_native"
+      "specialization": "go_microservices_cloud_native",
+      "focus": "Microservices, gRPC, Kubernetes operators"
     },
     "java-expert": {
       "enabled": true,
@@ -43,7 +56,8 @@
       "config_file": "~/.claude/agents/java-expert/agent.json",
       "prompt_file": "~/.claude/agents/java-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "java_spring_boot_enterprise"
+      "specialization": "java_spring_boot_enterprise",
+      "focus": "Spring Boot, Maven/Gradle, enterprise apps"
     },
     "python-expert": {
       "enabled": true,
@@ -51,7 +65,8 @@
       "config_file": "~/.claude/agents/python-expert/agent.json",
       "prompt_file": "~/.claude/agents/python-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "python_web_data_science_automation"
+      "specialization": "python_web_data_science_automation",
+      "focus": "Django/Flask, data science, automation"
     },
     "typescript-expert": {
       "enabled": true,
@@ -59,7 +74,8 @@
       "config_file": "~/.claude/agents/typescript-expert/agent.json",
       "prompt_file": "~/.claude/agents/typescript-expert.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "typescript_javascript_react_nodejs"
+      "specialization": "typescript_javascript_react_nodejs",
+      "focus": "React/Next.js, Node.js, frontend/backend"
     },
     "mql-trading-dev": {
       "enabled": true,
@@ -67,7 +83,8 @@
       "config_file": "~/.claude/agents/mql-trading-dev/agent.json",
       "prompt_file": "~/.claude/agents/mql-trading-dev.md",
       "model": "claude-opus-4-6-20250805",
-      "specialization": "mql4_mql5_metatrader_trading_systems"
+      "specialization": "mql4_mql5_metatrader_trading_systems",
+      "focus": "MQL4/MQL5, C/C++ DLLs, MetaTrader trading systems"
     },
     "bash-expert": {
       "enabled": true,
@@ -75,7 +92,8 @@
       "config_file": "~/.claude/agents/bash-expert/agent.json",
       "prompt_file": "~/.claude/agents/bash-expert.md",
       "model": "claude-haiku-4-5-20251001",
-      "specialization": "bash_shell_linux_automation"
+      "specialization": "bash_shell_linux_automation",
+      "focus": "Shell scripting, Linux automation, CLI tools"
     },
     "powershell-expert": {
       "enabled": true,
@@ -83,7 +101,8 @@
       "config_file": "~/.claude/agents/powershell-expert/agent.json",
       "prompt_file": "~/.claude/agents/powershell-expert.md",
       "model": "claude-haiku-4-5-20251001",
-      "specialization": "powershell_windows_azure_automation"
+      "specialization": "powershell_windows_azure_automation",
+      "focus": "Windows administration, Azure/AWS automation"
     },
     "database-specialist": {
       "enabled": true,
@@ -91,7 +110,8 @@
       "config_file": "~/.claude/agents/database-specialist/agent.json",
       "prompt_file": "~/.claude/agents/database-specialist.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "database_design_optimization_sql_nosql"
+      "specialization": "database_design_optimization_sql_nosql",
+      "focus": "Schema design, query optimization, SQL/NoSQL"
     },
     "frontend-specialist": {
       "enabled": true,
@@ -99,7 +119,8 @@
       "config_file": "~/.claude/agents/frontend-specialist/agent.json",
       "prompt_file": "~/.claude/agents/frontend-specialist.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "frontend_react_vue_angular_responsive"
+      "specialization": "frontend_react_vue_angular_responsive",
+      "focus": "React/Vue/Angular, responsive design, accessibility"
     },
     "security-specialist": {
       "enabled": true,
@@ -107,7 +128,8 @@
       "config_file": "~/.claude/agents/security-specialist/agent.json",
       "prompt_file": "~/.claude/agents/security-specialist.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "security_auditing_owasp_compliance"
+      "specialization": "security_auditing_owasp_compliance",
+      "focus": "Vulnerability assessment, compliance, auth"
     },
     "uiux-specialist": {
       "enabled": true,
@@ -115,7 +137,8 @@
       "config_file": "~/.claude/agents/uiux-specialist/agent.json",
       "prompt_file": "~/.claude/agents/uiux-specialist.md",
       "model": "claude-haiku-4-5-20251001",
-      "specialization": "uiux_design_accessibility_usability"
+      "specialization": "uiux_design_accessibility_usability",
+      "focus": "User flows, design systems, wireframing"
     },
     "devops-orchestrator": {
       "enabled": true,
@@ -123,7 +146,8 @@
       "config_file": "~/.claude/agents/devops-orchestrator/agent.json",
       "prompt_file": "~/.claude/agents/devops-orchestrator.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "infrastructure_deployment_cicd"
+      "specialization": "infrastructure_deployment_cicd",
+      "focus": "CI/CD, containers, cloud deployment, monitoring"
     },
     "system-architect": {
       "enabled": true,
@@ -131,7 +155,8 @@
       "config_file": "~/.claude/agents/system-architect/agent.json",
       "prompt_file": "~/.claude/agents/system-architect.md",
       "model": "claude-opus-4-6-20250805",
-      "specialization": "system_design_architecture_patterns"
+      "specialization": "system_design_architecture_patterns",
+      "focus": "System design, technology selection, SOLID principles"
     },
     "comprehensive-analyst": {
       "enabled": true,
@@ -139,7 +164,8 @@
       "config_file": "~/.claude/agents/comprehensive-analyst/agent.json",
       "prompt_file": "~/.claude/agents/comprehensive-analyst.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "deep_analysis_investigation_debugging"
+      "specialization": "deep_analysis_investigation_debugging",
+      "focus": "Security audits, performance profiling, investigation"
     },
     "code-review-gatekeeper": {
       "enabled": true,
@@ -147,7 +173,8 @@
       "config_file": "~/.claude/agents/code-review-gatekeeper/agent.json",
       "prompt_file": "~/.claude/agents/code-review-gatekeeper.md",
       "model": "claude-opus-4-6-20250805",
-      "specialization": "quality_enforcement_code_review"
+      "specialization": "quality_enforcement_code_review",
+      "focus": "Code review, quality gates, standards compliance"
     },
     "peer-review-critic": {
       "enabled": true,
@@ -155,7 +182,8 @@
       "config_file": "~/.claude/agents/peer-review-critic/agent.json",
       "prompt_file": "~/.claude/agents/peer-review-critic.md",
       "model": "claude-opus-4-6-20250805",
-      "specialization": "independent_peer_review_final_gate"
+      "specialization": "independent_peer_review_final_gate",
+      "focus": "Final independent peer review — diff-scoped gatekeeper (branch vs base)"
     },
     "technical-docs-writer": {
       "enabled": true,
@@ -163,7 +191,8 @@
       "config_file": "~/.claude/agents/technical-docs-writer/agent.json",
       "prompt_file": "~/.claude/agents/technical-docs-writer.md",
       "model": "claude-haiku-4-5-20251001",
-      "specialization": "documentation_technical_writing"
+      "specialization": "documentation_technical_writing",
+      "focus": "API docs, user guides, architecture docs"
     },
     "product-owner": {
       "enabled": true,
@@ -171,7 +200,8 @@
       "config_file": "~/.claude/agents/product-owner/agent.json",
       "prompt_file": "~/.claude/agents/product-owner.md",
       "model": "claude-sonnet-4-6-20250514",
-      "specialization": "product_management_requirements_planning"
+      "specialization": "product_management_requirements_planning",
+      "focus": "User stories, backlog management, acceptance criteria"
     }
   },
 

--- a/commands/list-agents.md
+++ b/commands/list-agents.md
@@ -155,6 +155,7 @@ Total: 20 agents (20 ready, 0 unavailable)
     }
   ],
   "summary": {
+    <!-- BEGIN GENERATED: list-agents-summary -->
     "total_agents": 20,
     "ready": 20,
     "unavailable": 0,
@@ -166,6 +167,7 @@ Total: 20 agents (20 ready, 0 unavailable)
       "quality_analysis": 3,
       "documentation": 1
     }
+    <!-- END GENERATED: list-agents-summary -->
   }
 }
 ```

--- a/hooks/core-hooks.json
+++ b/hooks/core-hooks.json
@@ -1,6 +1,6 @@
 {
   "version": "3.0",
-  "description": "Core hooks for 18-agent architecture with specialized routing",
+  "description": "Core hooks for 20-agent architecture with specialized routing",
   "hooks": {
     "development-standards": {
       "agents": ["language_experts"],
@@ -115,6 +115,7 @@
       "java-expert",
       "python-expert",
       "typescript-expert",
+      "mql-trading-dev",
       "bash-expert",
       "powershell-expert"
     ],
@@ -125,6 +126,7 @@
       "java-expert",
       "python-expert",
       "typescript-expert",
+      "mql-trading-dev",
       "bash-expert",
       "powershell-expert",
       "database-specialist",
@@ -135,6 +137,7 @@
       "system-architect",
       "comprehensive-analyst",
       "code-review-gatekeeper",
+      "peer-review-critic",
       "technical-docs-writer",
       "product-owner"
     ]

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# generate-docs.sh - Single-source documentation generator.
+#
+# Makes claude.json (+ the filesystem, via facts.sh) the single source of truth
+# for high-drift documentation blocks. Each generated block lives inside a
+# marker region:
+#
+#     <!-- BEGIN GENERATED: <id> -->
+#     ...rendered content...
+#     <!-- END GENERATED: <id> -->
+#
+# Modes:
+#   --write   Rewrite every registered marker region in place from the current
+#             canonical sources. Idempotent: on the correct tree this changes
+#             nothing visible (only ever the rendered bytes, which already match).
+#   --check   Render each block to memory and compare against what is currently
+#             between the markers. Exits non-zero and lists every STALE file
+#             (drifted block) without modifying anything. Intended for CI.
+#
+# Exit codes:
+#   0  success (--write done, or --check found everything fresh)
+#   1  --check found stale block(s), or a write failed
+#   2  usage error / missing prerequisite / malformed markers
+#
+# Requirements: bash, jq, awk.
+
+set -uo pipefail
+
+# --- locate repo + libraries (robust to any CWD) ---------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/facts.sh
+source "$SCRIPT_DIR/lib/facts.sh"
+# shellcheck source=scripts/lib/markers.sh
+source "$SCRIPT_DIR/lib/markers.sh"
+# shellcheck source=scripts/lib/render.sh
+source "$SCRIPT_DIR/lib/render.sh"
+
+ROOT="$FACTS_REPO_ROOT"
+
+# --- output helpers ---------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'; C_YEL=$'\033[1;33m'
+  C_CYN=$'\033[0;36m'; C_NC=$'\033[0m'
+else
+  C_RED=""; C_GRN=""; C_YEL=""; C_CYN=""; C_NC=""
+fi
+
+# --- the block registry -----------------------------------------------------
+# Each entry: "<relative-file>|<marker-id>|<render-function>"
+# The render function must print the EXACT region content (LF, no trailing
+# newline required - the markers layer normalizes that).
+#
+# NOTE ON COVERAGE: only blocks whose rendered text can be reproduced
+# byte-for-byte from the canonical sources are listed here. The README "## Agents"
+# tables are deliberately NOT generated: their section grouping and ordering
+# (e.g. "Architecture & Analysis" merges system-architect with the
+# quality_analysis agents while EXCLUDING product-owner, which README files
+# under "Planning & Requirements") does not match claude.json .agent_categories
+# and therefore cannot round-trip from it. Per the phase spec, correctness and
+# idempotency beat coverage: those tables are left ungenerated and instead
+# guarded by validate-consistency.sh (roster-presence + focus-text parity).
+BLOCKS=(
+  "commands/list-agents.md|list-agents-summary|render_list_agents_summary"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: generate-docs.sh (--write | --check)
+
+  --write   Regenerate all marker regions in place from claude.json + facts.
+  --check   Verify all marker regions are up to date; exit non-zero if stale.
+  -h|--help Show this help.
+EOF
+}
+
+# render_block <render-fn> -> stdout (LF, no enforced trailing newline)
+render_block() {
+  local fn="$1"
+  "$fn"
+}
+
+do_write() {
+  local rc=0 entry rel id fn file rendered
+  for entry in "${BLOCKS[@]}"; do
+    IFS='|' read -r rel id fn <<< "$entry"
+    file="$ROOT/$rel"
+    if [[ ! -f "$file" ]]; then
+      printf '%sERROR%s target file missing: %s\n' "$C_RED" "$C_NC" "$rel" >&2
+      rc=2; continue
+    fi
+    if ! markers_validate "$file" "$id"; then
+      rc=2; continue
+    fi
+    rendered="$(render_block "$fn")" || { printf '%sERROR%s render failed: %s\n' "$C_RED" "$C_NC" "$id" >&2; rc=1; continue; }
+    if markers_replace "$file" "$id" "$rendered"; then
+      printf '%sWROTE%s %s [%s]\n' "$C_GRN" "$C_NC" "$rel" "$id"
+    else
+      printf '%sERROR%s write failed: %s [%s]\n' "$C_RED" "$C_NC" "$rel" "$id" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
+do_check() {
+  local rc=0 entry rel id fn file rendered current stale_files=()
+  for entry in "${BLOCKS[@]}"; do
+    IFS='|' read -r rel id fn <<< "$entry"
+    file="$ROOT/$rel"
+    if [[ ! -f "$file" ]]; then
+      printf '%sERROR%s target file missing: %s\n' "$C_RED" "$C_NC" "$rel" >&2
+      rc=2; continue
+    fi
+    if ! markers_validate "$file" "$id"; then
+      rc=2; continue
+    fi
+    rendered="$(render_block "$fn")" || { printf '%sERROR%s render failed: %s\n' "$C_RED" "$C_NC" "$id" >&2; rc=1; continue; }
+    current="$(markers_extract "$file" "$id")" || { rc=2; continue; }
+    # Normalize both sides to "exactly one trailing newline" before comparing,
+    # mirroring what markers_replace writes, so trailing-newline noise never
+    # produces a false "stale".
+    if [[ "$(printf '%s\n' "$rendered")" == "$(printf '%s\n' "$current")" ]]; then
+      printf '%sFRESH%s %s [%s]\n' "$C_GRN" "$C_NC" "$rel" "$id"
+    else
+      printf '%sSTALE%s %s [%s]\n' "$C_RED" "$C_NC" "$rel" "$id"
+      stale_files+=("$rel [$id]")
+      rc=1
+    fi
+  done
+  if [[ "${#stale_files[@]}" -gt 0 ]]; then
+    printf '\n%sStale generated block(s) detected - run: bash scripts/generate-docs.sh --write%s\n' "$C_YEL" "$C_NC" >&2
+    local s
+    for s in "${stale_files[@]}"; do printf '  - %s\n' "$s" >&2; done
+  fi
+  return "$rc"
+}
+
+# --- preflight --------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%sERROR%s jq is required but not installed.\n' "$C_RED" "$C_NC" >&2
+  exit 2
+fi
+
+MODE=""
+case "${1:-}" in
+  --write) MODE="write" ;;
+  --check) MODE="check" ;;
+  -h|--help) usage; exit 0 ;;
+  "" ) printf '%sERROR%s no mode given.\n\n' "$C_RED" "$C_NC" >&2; usage >&2; exit 2 ;;
+  * )  printf '%sERROR%s unknown argument: %s\n\n' "$C_RED" "$C_NC" "$1" >&2; usage >&2; exit 2 ;;
+esac
+
+printf '%s== generate-docs (%s) :: repo %s ==%s\n' "$C_CYN" "$MODE" "$ROOT" "$C_NC"
+
+if [[ "$MODE" == "write" ]]; then
+  do_write; exit $?
+else
+  do_check; exit $?
+fi

--- a/scripts/lib/facts.sh
+++ b/scripts/lib/facts.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# facts.sh - Single shared facts layer for the anti-drift consistency system.
+#
+# Every fact exposed here is DERIVED at runtime from claude.json + the
+# filesystem. There are NO hardcoded agent names, counts, or lists. This file
+# is meant to be SOURCED (not executed) by validators and, later, generators:
+#
+#     source "$(dirname "$0")/lib/facts.sh"
+#     fact_agents
+#
+# Conventions:
+#   - Functions print to stdout, one item per line (or TAB-separated pairs).
+#   - The repo root is resolved robustly so callers work from any CWD.
+#   - All lookups go through jq against $FACTS_CLAUDE_JSON.
+#
+# Requirements: bash, jq.
+
+# --- guard against double-sourcing -----------------------------------------
+if [[ -n "${__FACTS_SH_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__FACTS_SH_LOADED=1
+
+# --- repo root resolution ---------------------------------------------------
+# Prefer git; fall back to walking up from this script's own location so the
+# library keeps working inside a tarball / detached checkout with no git.
+_facts_resolve_root() {
+  local here git_root
+  if git_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [[ -n "$git_root" ]]; then
+    printf '%s\n' "$git_root"
+    return 0
+  fi
+  # ${BASH_SOURCE[0]} is scripts/lib/facts.sh -> repo root is two levels up.
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+  if [[ -n "$here" && -f "$here/claude.json" ]]; then
+    printf '%s\n' "$here"
+    return 0
+  fi
+  # last resort: CWD
+  pwd
+}
+
+FACTS_REPO_ROOT="${FACTS_REPO_ROOT:-$(_facts_resolve_root)}"
+FACTS_CLAUDE_JSON="${FACTS_CLAUDE_JSON:-$FACTS_REPO_ROOT/claude.json}"
+FACTS_AGENTS_DIR="${FACTS_AGENTS_DIR:-$FACTS_REPO_ROOT/agents}"
+FACTS_HOOKS_DIR="${FACTS_HOOKS_DIR:-$FACTS_REPO_ROOT/hooks}"
+
+export FACTS_REPO_ROOT FACTS_CLAUDE_JSON FACTS_AGENTS_DIR FACTS_HOOKS_DIR
+
+# --- internal helpers -------------------------------------------------------
+_facts_require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'facts.sh: ERROR: jq is required but not installed.\n' >&2
+    return 127
+  fi
+}
+
+_facts_require_claude_json() {
+  if [[ ! -f "$FACTS_CLAUDE_JSON" ]]; then
+    printf 'facts.sh: ERROR: claude.json not found at %s\n' "$FACTS_CLAUDE_JSON" >&2
+    return 1
+  fi
+}
+
+# _facts_jq - jq wrapper that normalizes line endings to LF.
+# Some Windows/native jq builds emit CRLF on stdout regardless of input; that
+# stray CR breaks comm/diff/string comparisons downstream. Strip it here so
+# every fact is guaranteed LF-only and byte-clean on every platform.
+_facts_jq() {
+  jq "$@" | tr -d '\r'
+}
+
+# --- agent facts ------------------------------------------------------------
+
+# fact_agents - sorted agent names from claude.json .sub_agents | keys
+fact_agents() {
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  _facts_jq -r '.sub_agents | keys[]' "$FACTS_CLAUDE_JSON" | LC_ALL=C sort
+}
+
+# fact_agent_files - sorted basenames (without .md) of agents/*.md
+fact_agent_files() {
+  local f base
+  shopt -s nullglob
+  for f in "$FACTS_AGENTS_DIR"/*.md; do
+    base="$(basename "$f")"
+    printf '%s\n' "${base%.md}"
+  done | LC_ALL=C sort
+  shopt -u nullglob
+}
+
+# fact_categories - "category<TAB>agent" pairs from .agent_categories
+fact_categories() {
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  _facts_jq -r '.agent_categories | to_entries[] | .key as $c | .value[] | "\($c)\t\(.)"' \
+    "$FACTS_CLAUDE_JSON"
+}
+
+# fact_models - "agent<TAB>model_id" from .sub_agents
+fact_models() {
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  _facts_jq -r '.sub_agents | to_entries[] | "\(.key)\t\(.value.model)"' "$FACTS_CLAUDE_JSON" \
+    | LC_ALL=C sort
+}
+
+# --- consistency-block facts ------------------------------------------------
+
+# fact_allowlist - agents intentionally exempt from per-agent hook coverage
+fact_allowlist() {
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  _facts_jq -r '.consistency.hook_coverage_allowlist // [] | .[]' "$FACTS_CLAUDE_JSON" \
+    | LC_ALL=C sort
+}
+
+# fact_deprecated - dead/legacy agent names that must not appear as references
+fact_deprecated() {
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  _facts_jq -r '.consistency.deprecated_agent_names // [] | .[]' "$FACTS_CLAUDE_JSON"
+}
+
+# fact_model_shorthand <shorthand> - resolve a shorthand (opus/sonnet/haiku)
+# to its full model id via .consistency.model_shorthand_map. Prints nothing
+# and returns 1 if the shorthand is unknown.
+fact_model_shorthand() {
+  local sh="${1:-}"
+  _facts_require_jq || return $?
+  _facts_require_claude_json || return $?
+  if [[ -z "$sh" ]]; then
+    printf 'facts.sh: fact_model_shorthand requires a shorthand argument\n' >&2
+    return 2
+  fi
+  local id
+  id="$(_facts_jq -r --arg s "$sh" '.consistency.model_shorthand_map[$s] // empty' \
+        "$FACTS_CLAUDE_JSON")"
+  if [[ -z "$id" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$id"
+}
+
+# --- derived counts ---------------------------------------------------------
+
+# _facts_count_hook_json - number of hooks/*.json files
+_facts_count_hook_json() {
+  local f n=0
+  shopt -s nullglob
+  for f in "$FACTS_HOOKS_DIR"/*.json; do n=$((n + 1)); done
+  shopt -u nullglob
+  printf '%s\n' "$n"
+}
+
+# _facts_count_hook_yaml - number of hooks/*.yaml + hooks/*.yml files
+_facts_count_hook_yaml() {
+  local f n=0
+  shopt -s nullglob
+  for f in "$FACTS_HOOKS_DIR"/*.yaml "$FACTS_HOOKS_DIR"/*.yml; do n=$((n + 1)); done
+  shopt -u nullglob
+  printf '%s\n' "$n"
+}
+
+# _facts_count_agent_specific_hooks - number of hooks/*-validation.json files
+_facts_count_agent_specific_hooks() {
+  local f n=0
+  shopt -s nullglob
+  for f in "$FACTS_HOOKS_DIR"/*-validation.json; do n=$((n + 1)); done
+  shopt -u nullglob
+  printf '%s\n' "$n"
+}
+
+# fact_counts - emit derived counts as key=value lines.
+#   agents               = number of registered sub_agents
+#   hook_json            = number of hooks/*.json
+#   hook_yaml            = number of hooks/*.yaml(+.yml)
+#   agent_specific_hooks = number of hooks/*-validation.json
+#   framework_wide_hooks = hook_json - agent_specific_hooks
+#   quality_gates        = hook_json   (doc convention: "Total Hooks"/"quality gates")
+fact_counts() {
+  local agents hook_json hook_yaml agent_specific framework_wide
+  agents="$(fact_agents | grep -c . || true)"
+  hook_json="$(_facts_count_hook_json)"
+  hook_yaml="$(_facts_count_hook_yaml)"
+  agent_specific="$(_facts_count_agent_specific_hooks)"
+  framework_wide=$((hook_json - agent_specific))
+  printf 'agents=%s\n' "$agents"
+  printf 'hook_json=%s\n' "$hook_json"
+  printf 'hook_yaml=%s\n' "$hook_yaml"
+  printf 'agent_specific_hooks=%s\n' "$agent_specific"
+  printf 'framework_wide_hooks=%s\n' "$framework_wide"
+  printf 'quality_gates=%s\n' "$hook_json"
+}
+
+# fact_count <key> - convenience accessor: print the value for a single count
+# key emitted by fact_counts (e.g. fact_count agents).
+fact_count() {
+  local key="${1:?fact_count requires a key}"
+  fact_counts | awk -F= -v k="$key" '$1==k {print $2; found=1} END{exit !found}'
+}

--- a/scripts/lib/facts.sh
+++ b/scripts/lib/facts.sh
@@ -22,10 +22,24 @@ fi
 __FACTS_SH_LOADED=1
 
 # --- repo root resolution ---------------------------------------------------
-# Prefer git; fall back to walking up from this script's own location so the
-# library keeps working inside a tarball / detached checkout with no git.
+# Resolution order:
+#   1. FRAMEWORK_ROOT env override (explicit, highest precedence). Used by the
+#      test harness to pin resolution to an isolated temp copy of the repo even
+#      when that copy happens to live inside an unrelated git working tree (where
+#      `git rev-parse` would otherwise resolve to the WRONG root). Must point at
+#      a directory containing claude.json.
+#   2. git (`git rev-parse --show-toplevel`) for normal in-repo use.
+#   3. script-relative walk-up from this file's location so the library keeps
+#      working inside a tarball / detached / non-git checkout (e.g. a `cp -r`
+#      temp copy with no .git).
+#   4. CWD as a last resort.
 _facts_resolve_root() {
   local here git_root
+  # 1. explicit override (must actually look like the framework root)
+  if [[ -n "${FRAMEWORK_ROOT:-}" && -f "${FRAMEWORK_ROOT}/claude.json" ]]; then
+    ( cd "${FRAMEWORK_ROOT}" 2>/dev/null && pwd ) && return 0
+  fi
+  # 2. git
   if git_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [[ -n "$git_root" ]]; then
     printf '%s\n' "$git_root"
     return 0

--- a/scripts/lib/facts.sh
+++ b/scripts/lib/facts.sh
@@ -205,6 +205,8 @@ fact_counts() {
   printf 'hook_yaml=%s\n' "$hook_yaml"
   printf 'agent_specific_hooks=%s\n' "$agent_specific"
   printf 'framework_wide_hooks=%s\n' "$framework_wide"
+  # "quality gates" == count of hook JSON files (each hooks/*.json is one gate);
+  # this is the number docs render as "N Quality Gates".
   printf 'quality_gates=%s\n' "$hook_json"
 }
 

--- a/scripts/lib/facts.sh
+++ b/scripts/lib/facts.sh
@@ -81,7 +81,11 @@ _facts_require_claude_json() {
 # stray CR breaks comm/diff/string comparisons downstream. Strip it here so
 # every fact is guaranteed LF-only and byte-clean on every platform.
 _facts_jq() {
+  # Return jq's exit status (not tr's) via PIPESTATUS, so a jq failure is
+  # detectable by callers regardless of whether they have `set -o pipefail`
+  # (e.g. the `_facts_jq ... || cat` fallback in validate-consistency.sh).
   jq "$@" | tr -d '\r'
+  return "${PIPESTATUS[0]}"
 }
 
 # --- agent facts ------------------------------------------------------------

--- a/scripts/lib/markers.sh
+++ b/scripts/lib/markers.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# markers.sh - LF-safe, idempotent in-place replacement of content between
+# generator marker comments.
+#
+# A "marker region" is delimited by a matched pair of HTML comments carrying
+# the SAME id:
+#
+#     <!-- BEGIN GENERATED: <id> -->
+#     ...generated content (any number of lines)...
+#     <!-- END GENERATED: <id> -->
+#
+# markers_replace replaces ONLY the lines strictly between the two marker
+# comments, leaving the marker lines themselves and everything outside the
+# region byte-for-byte untouched. This makes a re-run with identical generated
+# content a true no-op (idempotency), which the round-trip test depends on.
+#
+# Design notes / guarantees:
+#   - Pure bash + standard awk. No sed -i, no in-place editors that mangle EOL.
+#   - Output is always LF-only (the repo is .gitattributes eol=lf). The marker
+#     lines are re-emitted verbatim from the source file, and the injected
+#     content is normalized to LF (any stray CR is stripped) so a CRLF-tainted
+#     payload can never leak into an LF file.
+#   - A trailing newline is always emitted for the injected content block, so
+#     the END marker sits on its own line exactly as it did before.
+#   - Errors (missing id, unbalanced/duplicate markers, nested markers) are
+#     reported to stderr and return non-zero WITHOUT modifying the target.
+#
+# This file is meant to be SOURCED:
+#     source "$(dirname "$0")/lib/markers.sh"
+#
+# Requirements: bash, awk, mktemp.
+
+# --- guard against double-sourcing -----------------------------------------
+if [[ -n "${__MARKERS_SH_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__MARKERS_SH_LOADED=1
+
+# markers_begin <id> - print the canonical BEGIN marker line for <id>.
+markers_begin() { printf '<!-- BEGIN GENERATED: %s -->' "$1"; }
+# markers_end <id> - print the canonical END marker line for <id>.
+markers_end()   { printf '<!-- END GENERATED: %s -->'   "$1"; }
+
+# markers_has <file> <id>
+#   Return 0 if <file> contains a single, well-formed BEGIN/END pair for <id>.
+#   Return non-zero (and print nothing) otherwise. Useful as a precondition.
+markers_has() {
+  local file="$1" id="$2"
+  [[ -f "$file" ]] || return 1
+  awk -v id="$id" '
+    index($0, "<!-- BEGIN GENERATED: " id " -->") { b++ }
+    index($0, "<!-- END GENERATED: "   id " -->") { e++ }
+    END { exit !(b == 1 && e == 1) }
+  ' "$file"
+}
+
+# markers_validate <file> <id>
+#   Strict structural validation of the region for <id> in <file>. Prints a
+#   precise diagnostic to stderr and returns non-zero on any problem:
+#     - file missing
+#     - BEGIN missing / appears more than once
+#     - END   missing / appears more than once
+#     - END appears before BEGIN
+#   Returns 0 (silent) when exactly one well-ordered pair exists.
+markers_validate() {
+  local file="$1" id="$2"
+  if [[ ! -f "$file" ]]; then
+    printf 'markers.sh: ERROR: file not found: %s\n' "$file" >&2
+    return 1
+  fi
+  awk -v id="$id" -v file="$file" '
+    index($0, "<!-- BEGIN GENERATED: " id " -->") { b++; if (b==1) bline=NR }
+    index($0, "<!-- END GENERATED: "   id " -->") { e++; if (e==1) eline=NR }
+    END {
+      if (b == 0) { printf("markers.sh: ERROR: missing BEGIN marker for id \x27%s\x27 in %s\n", id, file) > "/dev/stderr"; exit 2 }
+      if (b > 1)  { printf("markers.sh: ERROR: duplicate BEGIN marker for id \x27%s\x27 in %s (%d found)\n", id, file, b) > "/dev/stderr"; exit 2 }
+      if (e == 0) { printf("markers.sh: ERROR: missing END marker for id \x27%s\x27 in %s\n", id, file) > "/dev/stderr"; exit 2 }
+      if (e > 1)  { printf("markers.sh: ERROR: duplicate END marker for id \x27%s\x27 in %s (%d found)\n", id, file, e) > "/dev/stderr"; exit 2 }
+      if (eline < bline) { printf("markers.sh: ERROR: END marker precedes BEGIN marker for id \x27%s\x27 in %s\n", id, file) > "/dev/stderr"; exit 2 }
+    }
+  ' "$file"
+}
+
+# markers_extract <file> <id>
+#   Print (to stdout) the current content strictly between the BEGIN/END
+#   markers for <id>, LF-normalized, exactly as it lives in the file (used by
+#   --check to compare against freshly rendered content). Returns non-zero if
+#   the region is not well-formed.
+markers_extract() {
+  local file="$1" id="$2"
+  markers_validate "$file" "$id" || return $?
+  awk -v id="$id" '
+    index($0, "<!-- END GENERATED: " id " -->")   { inside=0 }
+    inside { print }
+    index($0, "<!-- BEGIN GENERATED: " id " -->") { inside=1 }
+  ' "$file" | tr -d '\r'
+}
+
+# markers_replace <file> <id> <content>
+#   Replace the lines strictly between the BEGIN/END markers for <id> in <file>
+#   with <content> (passed as a single string; embedded LFs are honored). The
+#   marker lines and all surrounding bytes are preserved verbatim. The write is
+#   atomic (temp file + mv) and LF-only. Returns non-zero (leaving <file>
+#   untouched) if the region is malformed.
+#
+#   Idempotency: if <content> already equals the current region content, the
+#   resulting file is byte-identical to the input.
+markers_replace() {
+  local file="$1" id="$2" content="$3"
+
+  markers_validate "$file" "$id" || return $?
+
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/markers.XXXXXX")" || {
+    printf 'markers.sh: ERROR: failed to create temp file\n' >&2
+    return 1
+  }
+
+  # Normalize the payload to LF-only and guarantee exactly one trailing LF so
+  # the END marker lands on its own line. printf '%s\n' adds the final LF; we
+  # strip any CRs the caller may have introduced.
+  local clean
+  clean="$(printf '%s' "$content" | tr -d '\r')"
+
+  # awk streams the file: copy everything up to and including BEGIN, then on the
+  # BEGIN line flush the new payload, suppress old region lines until END, then
+  # resume verbatim from END onward. The payload is fed via a separate file to
+  # avoid any quoting/escaping hazards inside awk.
+  local payload
+  payload="$(mktemp "${TMPDIR:-/tmp}/markers.payload.XXXXXX")" || {
+    rm -f "$tmp"
+    printf 'markers.sh: ERROR: failed to create payload temp file\n' >&2
+    return 1
+  }
+  # Only emit a payload line-block if there is content; an empty region stays
+  # empty (no spurious blank line injected).
+  if [[ -n "$clean" ]]; then
+    printf '%s\n' "$clean" > "$payload"
+  else
+    : > "$payload"
+  fi
+
+  awk -v id="$id" -v payload="$payload" '
+    BEGIN { inside = 0 }
+    {
+      if (index($0, "<!-- BEGIN GENERATED: " id " -->")) {
+        print $0
+        # stream the payload file verbatim
+        while ((getline line < payload) > 0) print line
+        close(payload)
+        inside = 1
+        next
+      }
+      if (index($0, "<!-- END GENERATED: " id " -->")) {
+        inside = 0
+        print $0
+        next
+      }
+      if (!inside) print $0
+    }
+  ' "$file" > "$tmp" || {
+    rm -f "$tmp" "$payload"
+    printf 'markers.sh: ERROR: awk replacement failed for id %s in %s\n' "$id" "$file" >&2
+    return 1
+  }
+
+  rm -f "$payload"
+
+  # Final guarantee: strip any CR that could have crept in, then move into place.
+  tr -d '\r' < "$tmp" > "$tmp.lf" && mv -f "$tmp.lf" "$file"
+  local rc=$?
+  rm -f "$tmp"
+  return $rc
+}

--- a/scripts/lib/markers.sh
+++ b/scripts/lib/markers.sh
@@ -10,9 +10,13 @@
 #     <!-- END GENERATED: <id> -->
 #
 # markers_replace replaces ONLY the lines strictly between the two marker
-# comments, leaving the marker lines themselves and everything outside the
-# region byte-for-byte untouched. This makes a re-run with identical generated
-# content a true no-op (idempotency), which the round-trip test depends on.
+# comments, leaving the marker lines themselves and the surrounding content
+# intact, with one deliberate normalization: the file is written LF-only and is
+# guaranteed to end with exactly one trailing LF (the repo enforces
+# .gitattributes eol=lf, so this is a no-op on a well-formed source file). Apart
+# from that EOL normalization, bytes outside the region are preserved verbatim.
+# This makes a re-run with identical generated content a true no-op
+# (idempotency), which the round-trip test depends on.
 #
 # Design notes / guarantees:
 #   - Pure bash + standard awk. No sed -i, no in-place editors that mangle EOL.

--- a/scripts/lib/render.sh
+++ b/scripts/lib/render.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# render.sh - One render function per generated documentation block.
+#
+# Every render_* function below builds the EXACT text that belongs inside a
+# marker region, reading ONLY from the canonical sources:
+#   - scripts/lib/facts.sh  (derived agent set / counts)
+#   - claude.json           (.agent_categories, .consistency.doc_blocks, .sub_agents.*.focus)
+#
+# Hard rules:
+#   - Output is LF-only (we route jq output through facts.sh's CR-stripping
+#     wrapper, and printf emits LF on every platform).
+#   - The text produced for the CURRENT (correct) tree MUST be byte-identical to
+#     what already lives between the markers, so the first `--write` is a no-op
+#     on visible content (idempotency / clean round-trip).
+#   - No hardcoded counts or agent names: everything is derived.
+#
+# This file is meant to be SOURCED (it depends on facts.sh being loaded):
+#     source "$(dirname "$0")/lib/facts.sh"
+#     source "$(dirname "$0")/lib/render.sh"
+#
+# Requirements: bash, jq (via facts.sh).
+
+# --- guard against double-sourcing -----------------------------------------
+if [[ -n "${__RENDER_SH_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__RENDER_SH_LOADED=1
+
+# Ensure facts.sh is available (it defines _facts_jq, FACTS_CLAUDE_JSON, etc.).
+if [[ -z "${__FACTS_SH_LOADED:-}" ]]; then
+  # Best-effort autoload from the same lib directory.
+  # shellcheck source=scripts/lib/facts.sh
+  source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/facts.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Block: list-agents-summary
+#   Renders the data-bearing lines of the JSON `summary` object inside the
+#   ```json sample in commands/list-agents.md. The category map is single-
+#   sourced: each doc-facing key sums the sizes of one or more REAL
+#   .agent_categories groups, as declared in
+#   .consistency.doc_blocks.list_agents_summary_categories (an ordered object,
+#   so jq's key order == the order we emit, matching the existing doc).
+#
+#   Emitted text (4/6-space indentation, matching the sample's nesting):
+#       "total_agents": <N>,
+#       "ready": <N>,
+#       "unavailable": 0,
+#       "categories": {
+#         "<doc_key>": <sum>,
+#         ...
+#         "<last_doc_key>": <sum>
+#       }
+#
+#   total_agents/ready are derived from the agent registry; unavailable is a
+#   structural literal (no source of truth for "unavailable" agents exists -
+#   every registered agent is enabled). The trailing closing brace of the
+#   categories object is part of the region; the OUTER summary `}` is left
+#   outside the marker region.
+# ---------------------------------------------------------------------------
+render_list_agents_summary() {
+  local total ready
+  total="$(fact_count agents)"
+  ready="$total"          # all registered agents are enabled => ready == total
+
+  # Build "<doc_key>=<sum>" lines, preserving the declared order, where <sum>
+  # is the total membership of all mapped .agent_categories groups. jq does the
+  # arithmetic against the live .agent_categories so the counts can never drift.
+  local lines
+  lines="$(_facts_jq -r '
+    .agent_categories as $cats
+    | .consistency.doc_blocks.list_agents_summary_categories
+    | to_entries[]
+    | .key as $doc
+    | ([.value[] | ($cats[.] // []) | length] | add // 0) as $sum
+    | "\($doc)=\($sum)"
+  ' "$FACTS_CLAUDE_JSON")" || return 1
+
+  # Emit the fixed leading triple.
+  printf '    "total_agents": %s,\n' "$total"
+  printf '    "ready": %s,\n' "$ready"
+  printf '    "unavailable": 0,\n'
+  printf '    "categories": {\n'
+
+  # Emit each category line; the LAST one omits the trailing comma (valid JSON).
+  local n i key val
+  n="$(printf '%s\n' "$lines" | grep -c .)"
+  i=0
+  while IFS='=' read -r key val; do
+    [[ -z "$key" ]] && continue
+    i=$((i + 1))
+    if [[ "$i" -lt "$n" ]]; then
+      printf '      "%s": %s,\n' "$key" "$val"
+    else
+      printf '      "%s": %s\n' "$key" "$val"
+    fi
+  done <<< "$lines"
+
+  # Close the categories object. NOTE: printf with no trailing \n here; the
+  # markers layer adds exactly one final LF for the region.
+  printf '    }'
+}
+
+# ---------------------------------------------------------------------------
+# render_focus <agent>
+#   Helper exposing the single-sourced focus string for one agent (from
+#   claude.json .sub_agents[<agent>].focus). Returns non-zero if absent.
+#   Available for any future README-table generation; the README tables are
+#   intentionally NOT generated in this phase (grouping cannot round-trip from
+#   .agent_categories - see scripts/generate-docs.sh notes), but the validator
+#   uses this to cross-check the prose table against the canonical field.
+# ---------------------------------------------------------------------------
+render_focus() {
+  local agent="${1:?render_focus requires an agent name}" val
+  val="$(_facts_jq -r --arg a "$agent" '.sub_agents[$a].focus // empty' "$FACTS_CLAUDE_JSON")" || return 1
+  [[ -n "$val" ]] || return 1
+  printf '%s' "$val"
+}

--- a/scripts/validate-agents.sh
+++ b/scripts/validate-agents.sh
@@ -1,48 +1,53 @@
-#!/bin/bash
-# validate-agents.sh - Quick agent validation script
+#!/usr/bin/env bash
+# validate-agents.sh - Quick agent validation (dynamic, no hardcoded roster).
+#
+# Derives the expected agent set from claude.json + the filesystem via the
+# shared facts layer. There is NO frozen EXPECTED_AGENTS list and NO hardcoded
+# count: registry and filesystem are compared to each other.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/facts.sh
+source "$SCRIPT_DIR/lib/facts.sh"
 
 echo "🤖 Agent Validation Check"
 echo "=========================="
 echo ""
 
-EXPECTED_AGENTS=(
-  "rust-expert"
-  "csharp-expert"
-  "go-expert"
-  "java-expert"
-  "python-expert"
-  "typescript-expert"
-  "bash-expert"
-  "powershell-expert"
-  "database-specialist"
-  "frontend-specialist"
-  "security-specialist"
-  "uiux-specialist"
-  "devops-orchestrator"
-  "system-architect"
-  "comprehensive-analyst"
-  "code-review-gatekeeper"
-  "technical-docs-writer"
-  "product-owner"
-)
+agents="$(fact_agents)"
+files="$(fact_agent_files)"
+n_agents="$(printf '%s\n' "$agents" | grep -c .)"
 
 MISSING=0
 
-for agent in "${EXPECTED_AGENTS[@]}"; do
-  if [ -f "agents/${agent}.md" ]; then
+# Every registered agent must have a corresponding agents/<name>.md file.
+while IFS= read -r agent; do
+  [[ -z "$agent" ]] && continue
+  if [[ -f "$FACTS_AGENTS_DIR/${agent}.md" ]]; then
     echo "✅ ${agent}"
   else
-    echo "❌ ${agent} MISSING"
-    ((MISSING++))
+    echo "❌ ${agent} MISSING (no agents/${agent}.md)"
+    MISSING=$((MISSING + 1))
   fi
-done
+done <<< "$agents"
+
+# Report any orphan .md files not registered in claude.json.
+ORPHANS="$(comm -13 <(printf '%s\n' "$agents") <(printf '%s\n' "$files"))"
+if [[ -n "$ORPHANS" ]]; then
+  while IFS= read -r orphan; do
+    [[ -z "$orphan" ]] && continue
+    echo "❌ ${orphan} ORPHAN (agents/${orphan}.md not in claude.json)"
+    MISSING=$((MISSING + 1))
+  done <<< "$ORPHANS"
+fi
 
 echo ""
 echo "================================"
-if [ $MISSING -eq 0 ]; then
-  echo "✅ All 18 agents present"
+if [[ "$MISSING" -eq 0 ]]; then
+  echo "✅ All ${n_agents} agents present and registered"
   exit 0
 else
-  echo "❌ Missing $MISSING agents"
+  echo "❌ ${MISSING} agent parity issue(s) found"
   exit 1
 fi

--- a/scripts/validate-agents.sh
+++ b/scripts/validate-agents.sh
@@ -6,6 +6,9 @@
 # count: registry and filesystem are compared to each other.
 
 set -uo pipefail
+# Force C collation so `comm` matches the facts layer's `LC_ALL=C sort` (else
+# bogus orphan/missing results under a non-C locale).
+export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/facts.sh

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -49,6 +49,28 @@ info()  { printf '  %sINFO%s  %s\n' "$C_CYN" "$C_NC" "$1"; }
 detail(){ printf '          %s\n' "$1"; }
 section(){ printf '\n%s%s%s\n' "$C_CYN" "$1" "$C_NC"; }
 
+# _esc_ere <string> - backslash-escape every ERE metacharacter in <string> so
+# it can be embedded as a LITERAL inside a larger regex. Implemented in pure
+# bash (substring membership, no sed/glob pattern parsing) so it is immune to
+# platform sed quirks (POSIX collating symbols, backslash-in-bracket-class) and
+# to metacharacters in the input itself. Replaces the previous
+# `sed 's/[..]/\\&/g'`, which emitted a literal '&' on this platform's sed and
+# silently failed to escape (false negatives).
+_esc_ere() {
+  local s="${1-}" out="" ch i
+  local meta='.[]{}()*+?^$|\'
+  local bs='\'
+  for (( i=0; i<${#s}; i++ )); do
+    ch="${s:i:1}"
+    if [[ "$meta" == *"$ch"* ]]; then
+      out="${out}${bs}${ch}"
+    else
+      out="${out}${ch}"
+    fi
+  done
+  printf '%s' "$out"
+}
+
 # --- preflight --------------------------------------------------------------
 if ! command -v jq >/dev/null 2>&1; then
   printf '%sERROR%s jq is required but not installed.\n' "$C_RED" "$C_NC" >&2
@@ -194,7 +216,6 @@ section "[3] Hook coverage (every non-allowlisted agent has {agent}-validation.j
 section "[4] JSON validity (hooks/*.json, claude.json, shared/*.json) + YAML best-effort"
 {
   json_bad=0 json_total=0
-  add_json() { :; }
   # Collect target json files.
   json_files=()
   [[ -f "$ROOT/claude.json" ]] && json_files+=("$ROOT/claude.json")
@@ -295,17 +316,23 @@ section "[5] Deprecated agent names (no live references in config or active doc 
 
   while IFS= read -r name; do
     [[ -z "$name" ]] && continue
-    esc="$(printf '%s' "$name" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')"
 
-    # Structured config: deprecated name as a JSON string token.
-    # EXCLUDE the consistency block's OWN canonical definition lines
-    # (deprecated_agent_names / hook_coverage_allowlist / model_shorthand_map),
-    # which legitimately enumerate these names. Those keys only ever appear in
-    # claude.json's consistency block, so filtering by key name is exact.
+    # Structured config: deprecated name as a JSON string token "<name>".
+    # The canonical lists that legitimately enumerate these names all live under
+    # the .consistency block (deprecated_agent_names / hook_coverage_allowlist /
+    # model_shorthand_map). We exclude them STRUCTURALLY by deleting that block
+    # with jq before scanning, rather than text-filtering by key name (which is
+    # coupled to single-line JSON layout and breaks under `jq '.'` reformatting).
+    # The literal token is matched with fixed-string grep (-F) so a name
+    # containing a regex metacharacter still matches exactly and cannot break
+    # the pattern.
     for f in "${json_scope[@]}"; do
       [[ -f "$f" ]] || continue
-      hits="$(grep -nE "\"${esc}\"" "$f" 2>/dev/null \
-              | grep -vE '"(deprecated_agent_names|hook_coverage_allowlist|model_shorthand_map)"')"
+      # Strip .consistency so the canonical lists are never scanned. If jq fails
+      # for any reason, fall back to scanning the raw file (fail-safe: catch more,
+      # never silently skip).
+      scan="$(_facts_jq 'del(.consistency)' "$f" 2>/dev/null || cat "$f")"
+      hits="$(printf '%s\n' "$scan" | grep -nF "\"$name\"")"
       if [[ -n "$hits" ]]; then
         ok=0
         fail "deprecated name '$name' used as config token in ${f#"$ROOT"/}:"
@@ -314,6 +341,10 @@ section "[5] Deprecated agent names (no live references in config or active doc 
     done
 
     # Docs: only ACTIVE references (path / routing directive), not prose.
+    # Only the variable part (<name>) is interpolated into this otherwise-fixed
+    # structural regex, so we metachar-escape it with _esc_ere (a name with a
+    # regex metachar can therefore neither break the pattern nor over-match).
+    esc="$(_esc_ere "$name")"
     active_re="agents/${esc}\.md|subagent_type[\"']?[[:space:]]*[:=][[:space:]]*[\"']?${esc}([\"', )]|\$)|\"agent\"[[:space:]]*:[[:space:]]*\"${esc}\"|(^|[[:space:](=])agent[[:space:]]*:[[:space:]]*${esc}([[:space:],)]|\$)"
     for f in "${doc_scope[@]}"; do
       [[ -f "$f" ]] || continue

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -21,6 +21,11 @@ set -uo pipefail
 # NOTE: -e is deliberately NOT set. We want to run every check and aggregate
 # results; a non-zero from a single grep/diff must not abort the whole run.
 
+# Force C collation so `comm`/`sort` agree on ordering on every locale. The
+# facts layer sorts with `LC_ALL=C sort`; `comm` must use the same collation or
+# it reports bogus missing/orphan diffs under a non-C user locale.
+export LC_ALL=C
+
 # --- locate + source the shared facts layer --------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/facts.sh

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -25,6 +25,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/facts.sh
 source "$SCRIPT_DIR/lib/facts.sh"
+# render.sh provides render_focus() for prose-table focus-text parity (check 10).
+# shellcheck source=scripts/lib/render.sh
+source "$SCRIPT_DIR/lib/render.sh"
 
 ROOT="$FACTS_REPO_ROOT"
 
@@ -523,6 +526,260 @@ section "[7] Model parity (agents/<a>.md frontmatter model: == claude.json model
     pass "all $checked agent frontmatter models agree with claude.json"
   else
     info "model parity is advisory: $mismatches mismatch(es), $unresolved unresolved of $checked checked (non-blocking)"
+  fi
+}
+
+# ===========================================================================
+# CHECK 9 - Roster-presence for NON-generated prose tables (BLOCKING)
+# ===========================================================================
+# These tables are NOT machine-generated (their grouping/order cannot round-trip
+# from claude.json - see generate-docs.sh). We therefore guard them here:
+#   (a) every registered agent appears EXACTLY ONCE in the roster,
+#   (b) no unknown/extra agent rows,
+#   (c) for the textual "### Category (N agents)" sections, the stated N equals
+#       the actual number of agents listed beneath that header.
+# This catches the missing-row / wrong-header-count drift without generating
+# the prose.
+section "[9] Roster-presence for prose tables (CLAUDE.md table + list-agents roster/categories)"
+{
+  ok=1
+
+  # _roster_compare <label> <newline-list-of-agents-extracted>
+  #   Compares an extracted roster against the canonical agent set:
+  #     - duplicate rows (agent listed more than once)
+  #     - unknown rows  (name not a registered agent)
+  #     - missing rows  (registered agent not present)
+  _roster_compare() {
+    local label="$1" extracted="$2"
+    local sorted dups unknown missing local_ok=1
+
+    sorted="$(printf '%s\n' "$extracted" | grep -v '^$' | LC_ALL=C sort)"
+
+    # (a) duplicates
+    dups="$(printf '%s\n' "$sorted" | uniq -d)"
+    if [[ -n "$dups" ]]; then
+      local_ok=0; ok=0
+      fail "$label: agent row(s) appear more than once:"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "duplicate-row: $a"; done <<< "$dups"
+    fi
+
+    # (b) unknown (in roster, not a real agent)
+    unknown="$(comm -23 <(printf '%s\n' "$sorted" | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+    if [[ -n "$unknown" ]]; then
+      local_ok=0; ok=0
+      fail "$label: unknown/extra agent row(s) (not in claude.json .sub_agents):"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "unknown-row: $a"; done <<< "$unknown"
+    fi
+
+    # (c) missing (real agent, absent from roster)
+    missing="$(comm -13 <(printf '%s\n' "$sorted" | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+    if [[ -n "$missing" ]]; then
+      local_ok=0; ok=0
+      fail "$label: registered agent(s) MISSING from roster:"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "missing-row: $a"; done <<< "$missing"
+    fi
+
+    if [[ "$local_ok" -eq 1 ]]; then
+      pass "$label: all $(printf '%s\n' "$AGENTS_SORTED" | grep -c .) agents present exactly once; no unknown rows"
+    fi
+  }
+
+  # --- 9a: CLAUDE.md "AVAILABLE IMPLEMENTATION AGENTS" table ----------------
+  # Rows look like:  | **agent-name** | Implementation domain |
+  # Scope the extraction to the table by only matching that exact row shape; the
+  # routing guidelines below use "- **Rust development**" (no leading pipe) so
+  # they cannot leak in.
+  claude_md="$ROOT/CLAUDE.md"
+  if [[ -f "$claude_md" ]]; then
+    cmd_roster="$(grep -oE '^\| \*\*[a-z0-9-]+\*\* \|' "$claude_md" \
+                  | sed -E 's/^\| \*\*//; s/\*\* \|$//')"
+    if [[ -z "$cmd_roster" ]]; then
+      ok=0; fail "CLAUDE.md: could not locate any agent table rows"
+    else
+      _roster_compare "CLAUDE.md agent table" "$cmd_roster"
+    fi
+  else
+    ok=0; fail "CLAUDE.md not found at $claude_md"
+  fi
+
+  # --- 9b: list-agents.md ASCII roster table --------------------------------
+  # Rows look like:  | rust-expert              | Language | ...   (box-drawing
+  # vertical bar U+2502). The file contains MORE THAN ONE box table (the main
+  # roster, plus a "--language" category-view EXAMPLE that re-lists the 9
+  # language/automation agents). We therefore scope extraction to the FIRST box
+  # table only: capture rows after the first top border (U+250C "\xe2\x94\x8c")
+  # and stop at its matching bottom border (U+2514 "\xe2\x94\x94"). Within that
+  # block we pull the first content cell and keep only agent-name-shaped tokens
+  # (header "Agent" and separator rows are naturally excluded).
+  la="$ROOT/commands/list-agents.md"
+  if [[ -f "$la" ]]; then
+    la_roster="$(awk '
+      # First top border opens the roster table.
+      !started && /^\xe2\x94\x8c/ { started=1; next }
+      started && /^\xe2\x94\x94/  { exit }            # bottom border closes it
+      started && /\xe2\x94\x82/ {
+        line=$0
+        n=split(line, cells, "\xe2\x94\x82")
+        cell=cells[2]                                  # first content cell
+        gsub(/^[ \t]+/, "", cell); gsub(/[ \t]+$/, "", cell)
+        if (cell ~ /^[a-z0-9]+(-[a-z0-9]+)+$/) print cell
+      }
+    ' "$la")"
+    if [[ -z "$la_roster" ]]; then
+      ok=0; fail "list-agents.md: could not locate any ASCII roster rows"
+    else
+      _roster_compare "list-agents.md ASCII roster" "$la_roster"
+
+      # Also validate the declared "Total: <N> agents" line against the roster.
+      declared_total="$(grep -oE 'Total: [0-9]+ agents' "$la" | head -1 | grep -oE '[0-9]+')"
+      actual_total="$(printf '%s\n' "$la_roster" | grep -c .)"
+      if [[ -n "$declared_total" && "$declared_total" != "$actual_total" ]]; then
+        ok=0
+        fail "list-agents.md roster: 'Total: $declared_total agents' != $actual_total rows in the table"
+      fi
+    fi
+
+    # --- 9c: list-agents.md textual "### Category (N agents)" sections ------
+    # Each header is followed by a fenced block of "agent-name -> ..." lines.
+    # We (1) verify the union of all listed agents is the full roster exactly,
+    # and (2) verify each header's stated N equals the agents listed beneath it.
+    cat_total_ok=1
+    all_cat_agents=""
+    # Iterate headers with their line numbers.
+    while IFS= read -r hline; do
+      [[ -z "$hline" ]] && continue
+      hnum="${hline%%:*}"
+      htext="${hline#*:}"
+      # stated N (the number inside "(N agent[s])")
+      stated="$(printf '%s' "$htext" | grep -oE '\([0-9]+ agents?\)' | grep -oE '[0-9]+')"
+      # Collect agent tokens from the lines AFTER this header up to the next
+      # "### " header (or EOF). An agent line looks like:
+      #   rust-expert          -> Rust systems programming
+      sect_agents="$(awk -v start="$hnum" '
+        NR > start {
+          if ($0 ~ /^### /) exit
+          # first token if it is an agent-name shape
+          tok=$1
+          if (tok ~ /^[a-z0-9]+(-[a-z0-9]+)+$/) print tok
+        }
+      ' "$la")"
+      actual="$(printf '%s\n' "$sect_agents" | grep -c .)"
+      all_cat_agents+="$sect_agents"$'\n'
+      if [[ "$stated" != "$actual" ]]; then
+        cat_total_ok=0; ok=0
+        fail "list-agents.md category header count mismatch: '$(printf '%s' "$htext" | sed -E 's/^[[:space:]]+//')' states $stated but lists $actual"
+        while IFS= read -r a; do [[ -n "$a" ]] && detail "listed: $a"; done <<< "$sect_agents"
+      fi
+    done <<< "$(grep -nE '^### .* \([0-9]+ agents?\)' "$la")"
+
+    # Union of textual-category agents must equal the full roster exactly.
+    if [[ -n "$all_cat_agents" ]]; then
+      _roster_compare "list-agents.md textual categories (union)" "$all_cat_agents"
+    else
+      ok=0; fail "list-agents.md: could not locate any '### Category (N agents)' sections"
+    fi
+    if [[ "$cat_total_ok" -eq 1 ]]; then
+      pass "list-agents.md: every '### Category (N agents)' header count matches its listed agents"
+    fi
+  else
+    ok=0; fail "list-agents.md not found at $la"
+  fi
+
+  [[ "$ok" -eq 1 ]] || true
+}
+
+# ===========================================================================
+# CHECK 10 - README focus-text parity (BLOCKING)
+# ===========================================================================
+# The README "## Agents" tables are NOT generated (grouping cannot round-trip),
+# but each agent's Focus column is now single-sourced as .sub_agents[a].focus.
+# Guard the prose against drift: every agent's README Focus cell must match the
+# canonical focus field byte-for-byte, the README must list every agent exactly
+# once, and contain no unknown agent rows.
+section "[10] README focus-text parity (.sub_agents[a].focus == README Focus cell)"
+{
+  readme="$ROOT/README.md"
+  ok=1
+  if [[ ! -f "$readme" ]]; then
+    ok=0; fail "README.md not found at $readme"
+  else
+    # Extract "agent<TAB>focus" pairs from the ## Agents section only.
+    readme_pairs="$(awk '
+      /^## Agents$/ {inagents=1; next}
+      inagents && /^## / {inagents=0}
+      inagents && /^\| \*\*[a-z0-9-]+\*\* \| / {
+        line=$0
+        sub(/^\| \*\*/, "", line)
+        idx=index(line, "** | ")
+        name=substr(line, 1, idx-1)
+        rest=substr(line, idx+5)
+        sub(/ \|$/, "", rest)
+        printf "%s\t%s\n", name, rest
+      }
+    ' "$readme")"
+
+    # Roster presence: agents listed in the README ## Agents tables.
+    readme_roster="$(printf '%s\n' "$readme_pairs" | awk -F'\t' 'NF{print $1}')"
+    readme_sorted="$(printf '%s\n' "$readme_roster" | grep -v '^$' | LC_ALL=C sort)"
+    r_dups="$(printf '%s\n' "$readme_sorted" | uniq -d)"
+    r_unknown="$(comm -23 <(printf '%s\n' "$readme_sorted" | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+    r_missing="$(comm -13 <(printf '%s\n' "$readme_sorted" | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+    if [[ -n "$r_dups" ]]; then
+      ok=0; fail "README ## Agents: duplicate agent row(s):"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "duplicate-row: $a"; done <<< "$r_dups"
+    fi
+    if [[ -n "$r_unknown" ]]; then
+      ok=0; fail "README ## Agents: unknown/extra agent row(s):"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "unknown-row: $a"; done <<< "$r_unknown"
+    fi
+    if [[ -n "$r_missing" ]]; then
+      ok=0; fail "README ## Agents: registered agent(s) MISSING from tables:"
+      while IFS= read -r a; do [[ -n "$a" ]] && detail "missing-row: $a"; done <<< "$r_missing"
+    fi
+
+    # Focus-text parity: README cell == claude.json focus field.
+    mismatch=0
+    while IFS=$'\t' read -r name foc; do
+      [[ -z "$name" ]] && continue
+      canon="$(render_focus "$name" 2>/dev/null || true)"
+      if [[ -z "$canon" ]]; then
+        ok=0; mismatch=$((mismatch + 1))
+        fail "README focus parity: '$name' has no .focus field in claude.json"
+      elif [[ "$foc" != "$canon" ]]; then
+        ok=0; mismatch=$((mismatch + 1))
+        fail "README focus parity: '$name' README cell != claude.json .focus"
+        detail "README:     $foc"
+        detail "claude.json: $canon"
+      fi
+    done <<< "$readme_pairs"
+
+    if [[ "$ok" -eq 1 ]]; then
+      pass "all $(printf '%s\n' "$readme_sorted" | grep -c .) README agent rows present once; focus text matches claude.json exactly"
+    fi
+  fi
+}
+
+# ===========================================================================
+# CHECK 11 - Generated blocks are fresh (BLOCKING) - wires in generate-docs
+# ===========================================================================
+# Runs the generator in --check mode so a stale machine-generated block (e.g.
+# the list-agents JSON summary) fails the same gate as everything else. Kept as
+# a separate script per the phase design; this is the single call site that lets
+# one `validate-consistency.sh` run cover both validation AND generation drift.
+section "[11] Generated documentation blocks are up to date (generate-docs.sh --check)"
+{
+  gen="$SCRIPT_DIR/generate-docs.sh"
+  if [[ ! -f "$gen" ]]; then
+    fail "generate-docs.sh not found at $gen"
+  else
+    gen_out="$(bash "$gen" --check 2>&1)"
+    gen_rc=$?
+    if [[ "$gen_rc" -eq 0 ]]; then
+      pass "all generated blocks are fresh"
+    else
+      fail "generate-docs.sh --check reported stale/invalid blocks (exit $gen_rc):"
+      while IFS= read -r ln; do [[ -n "$ln" ]] && detail "$ln"; done <<< "$gen_out"
+    fi
   fi
 }
 

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -1,0 +1,541 @@
+#!/usr/bin/env bash
+# validate-consistency.sh - Dynamic anti-drift consistency validator.
+#
+# Derives all "truth" at runtime from claude.json + the filesystem via the
+# shared facts layer (scripts/lib/facts.sh). NOTHING is hardcoded: no agent
+# names, no counts, no rosters. If the framework grows or shrinks, this script
+# adapts automatically.
+#
+# It runs a battery of checks, prints a clear PASS/FAIL per check with the
+# offending items, COLLECTS all failures (does not bail on the first), and
+# exits non-zero if ANY blocking check fails. WARNING checks print but never
+# affect the exit code.
+#
+# Usage:
+#   bash scripts/validate-consistency.sh
+#   echo "exit=$?"
+#
+# Requirements: bash, jq. (YAML validity is best-effort via python3/ruby.)
+
+set -uo pipefail
+# NOTE: -e is deliberately NOT set. We want to run every check and aggregate
+# results; a non-zero from a single grep/diff must not abort the whole run.
+
+# --- locate + source the shared facts layer --------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/facts.sh
+source "$SCRIPT_DIR/lib/facts.sh"
+
+ROOT="$FACTS_REPO_ROOT"
+
+# --- output helpers ---------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'; C_YEL=$'\033[1;33m'
+  C_CYN=$'\033[0;36m'; C_NC=$'\033[0m'
+else
+  C_RED=""; C_GRN=""; C_YEL=""; C_CYN=""; C_NC=""
+fi
+
+BLOCKING_FAILURES=0
+WARNINGS=0
+
+pass()  { printf '  %sPASS%s  %s\n' "$C_GRN" "$C_NC" "$1"; }
+fail()  { printf '  %sFAIL%s  %s\n' "$C_RED" "$C_NC" "$1"; BLOCKING_FAILURES=$((BLOCKING_FAILURES + 1)); }
+warn()  { printf '  %sWARN%s  %s\n' "$C_YEL" "$C_NC" "$1"; WARNINGS=$((WARNINGS + 1)); }
+info()  { printf '  %sINFO%s  %s\n' "$C_CYN" "$C_NC" "$1"; }
+detail(){ printf '          %s\n' "$1"; }
+section(){ printf '\n%s%s%s\n' "$C_CYN" "$1" "$C_NC"; }
+
+# --- preflight --------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%sERROR%s jq is required but not installed.\n' "$C_RED" "$C_NC" >&2
+  exit 2
+fi
+
+printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+printf '%s  Anti-Drift Consistency Validator%s\n' "$C_CYN" "$C_NC"
+printf '%s  repo: %s%s\n' "$C_CYN" "$ROOT" "$C_NC"
+printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+
+# Cache the canonical agent set once (sorted, newline-delimited).
+AGENTS_SORTED="$(fact_agents)"
+AGENT_FILES_SORTED="$(fact_agent_files)"
+
+# ===========================================================================
+# CHECK 1 - Registry <-> filesystem parity
+# ===========================================================================
+section "[1] Registry <-> filesystem parity (claude.json .sub_agents == agents/*.md)"
+{
+  missing_in_registry="$(comm -13 <(printf '%s\n' "$AGENTS_SORTED") <(printf '%s\n' "$AGENT_FILES_SORTED"))"
+  orphan_md="$missing_in_registry"           # .md present, not registered
+  missing_md="$(comm -23 <(printf '%s\n' "$AGENTS_SORTED") <(printf '%s\n' "$AGENT_FILES_SORTED"))"
+  # missing_md: registered but no .md file
+
+  ok=1
+  if [[ -n "$missing_md" ]]; then
+    ok=0
+    fail "Agents registered in claude.json with NO agents/<name>.md file:"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "missing-md: $a"; done <<< "$missing_md"
+  fi
+  if [[ -n "$orphan_md" ]]; then
+    ok=0
+    fail "Orphan agents/<name>.md files NOT registered in claude.json:"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "orphan-md: $a"; done <<< "$orphan_md"
+  fi
+  if [[ "$ok" -eq 1 ]]; then
+    pass "$(printf '%s\n' "$AGENTS_SORTED" | grep -c .) agents: registry and filesystem match exactly"
+  fi
+}
+
+# ===========================================================================
+# CHECK 2 - Category partition
+# ===========================================================================
+section "[2] Category partition (.agent_categories partitions all agents)"
+{
+  # Flatten category -> agent pairs.
+  cat_pairs="$(fact_categories)"            # category<TAB>agent
+  cat_agents_all="$(printf '%s\n' "$cat_pairs" | awk -F'\t' 'NF{print $2}')"
+  cat_agents_sorted="$(printf '%s\n' "$cat_agents_all" | LC_ALL=C sort)"
+  cat_agents_uniq="$(printf '%s\n' "$cat_agents_all" | LC_ALL=C sort -u)"
+
+  ok=1
+
+  # 2a: duplicates (agent in two groups)
+  dups="$(printf '%s\n' "$cat_agents_sorted" | uniq -d)"
+  if [[ -n "$dups" ]]; then
+    ok=0
+    fail "Agent(s) appear in more than one category:"
+    while IFS= read -r a; do
+      [[ -z "$a" ]] && continue
+      groups="$(printf '%s\n' "$cat_pairs" | awk -F'\t' -v x="$a" '$2==x{print $1}' | paste -sd, -)"
+      detail "duplicate: $a -> [$groups]"
+    done <<< "$dups"
+  fi
+
+  # 2b: unknown agent (in a category but not a real agent)
+  unknown="$(comm -23 <(printf '%s\n' "$cat_agents_uniq") <(printf '%s\n' "$AGENTS_SORTED"))"
+  if [[ -n "$unknown" ]]; then
+    ok=0
+    fail "Category references unknown agent(s) (not in .sub_agents):"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "unknown-in-category: $a"; done <<< "$unknown"
+  fi
+
+  # 2c: uncategorized agent (real agent missing from every category)
+  uncategorized="$(comm -13 <(printf '%s\n' "$cat_agents_uniq") <(printf '%s\n' "$AGENTS_SORTED"))"
+  if [[ -n "$uncategorized" ]]; then
+    ok=0
+    fail "Agent(s) not assigned to any category:"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "uncategorized: $a"; done <<< "$uncategorized"
+  fi
+
+  if [[ "$ok" -eq 1 ]]; then
+    ncat="$(printf '%s\n' "$cat_pairs" | awk -F'\t' 'NF{print $1}' | LC_ALL=C sort -u | grep -c .)"
+    pass "$ncat categories cleanly partition all $(printf '%s\n' "$AGENTS_SORTED" | grep -c .) agents (no dup, no unknown, no gap)"
+  fi
+}
+
+# ===========================================================================
+# CHECK 3 - Hook coverage
+# ===========================================================================
+section "[3] Hook coverage (every non-allowlisted agent has {agent}-validation.json)"
+{
+  allowlist_sorted="$(fact_allowlist)"
+
+  # Agents that REQUIRE a per-agent validation hook = agents minus allowlist.
+  required="$(comm -23 <(printf '%s\n' "$AGENTS_SORTED") <(printf '%s\n' "$allowlist_sorted"))"
+
+  # Existing *-validation.json -> derive the agent name (strip suffix).
+  shopt -s nullglob
+  existing_hook_agents=""
+  for f in "$FACTS_HOOKS_DIR"/*-validation.json; do
+    b="$(basename "$f")"
+    existing_hook_agents+="${b%-validation.json}"$'\n'
+  done
+  shopt -u nullglob
+  existing_sorted="$(printf '%s' "$existing_hook_agents" | grep -v '^$' | LC_ALL=C sort)"
+
+  ok=1
+
+  # 3a: required agent with no hook
+  no_hook="$(comm -23 <(printf '%s\n' "$required") <(printf '%s\n' "$existing_sorted"))"
+  if [[ -n "$no_hook" ]]; then
+    ok=0
+    fail "Agent(s) missing required hooks/<agent>-validation.json:"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "missing-hook: $a (expected hooks/${a}-validation.json)"; done <<< "$no_hook"
+  fi
+
+  # 3b: orphan validation hook (maps to no real agent)
+  orphan_hook="$(comm -23 <(printf '%s\n' "$existing_sorted") <(printf '%s\n' "$AGENTS_SORTED"))"
+  if [[ -n "$orphan_hook" ]]; then
+    ok=0
+    fail "Orphan *-validation.json hook(s) not mapping to any registered agent:"
+    while IFS= read -r a; do [[ -n "$a" ]] && detail "orphan-hook: hooks/${a}-validation.json"; done <<< "$orphan_hook"
+  fi
+
+  if [[ "$ok" -eq 1 ]]; then
+    pass "all $(printf '%s\n' "$required" | grep -c .) required agents have a validation hook; no orphan hooks"
+  fi
+
+  # Allowlisted agents are reported as INFO (intentionally not covered per-agent).
+  if [[ -n "$allowlist_sorted" ]]; then
+    while IFS= read -r a; do
+      [[ -z "$a" ]] && continue
+      info "allowlisted (no per-agent hook required): $a"
+    done <<< "$allowlist_sorted"
+  fi
+}
+
+# ===========================================================================
+# CHECK 4 - JSON validity (+ best-effort YAML validity)
+# ===========================================================================
+section "[4] JSON validity (hooks/*.json, claude.json, shared/*.json) + YAML best-effort"
+{
+  json_bad=0 json_total=0
+  add_json() { :; }
+  # Collect target json files.
+  json_files=()
+  [[ -f "$ROOT/claude.json" ]] && json_files+=("$ROOT/claude.json")
+  shopt -s nullglob
+  for f in "$FACTS_HOOKS_DIR"/*.json; do json_files+=("$f"); done
+  for f in "$ROOT"/shared/*.json; do json_files+=("$f"); done
+  shopt -u nullglob
+
+  for f in "${json_files[@]}"; do
+    json_total=$((json_total + 1))
+    if ! jq empty "$f" >/dev/null 2>&1; then
+      json_bad=$((json_bad + 1))
+      fail "invalid JSON: ${f#"$ROOT"/}"
+    fi
+  done
+  if [[ "$json_bad" -eq 0 ]]; then
+    pass "all $json_total JSON files parse cleanly (jq empty)"
+  fi
+
+  # YAML best-effort.
+  shopt -s nullglob
+  yaml_files=("$FACTS_HOOKS_DIR"/*.yaml "$FACTS_HOOKS_DIR"/*.yml)
+  shopt -u nullglob
+  if [[ "${#yaml_files[@]}" -eq 0 ]]; then
+    info "no YAML hook files present"
+  else
+    # Pick a YAML checker that ACTUALLY WORKS. `command -v python3` is not
+    # enough on Windows, where the Microsoft Store "app execution alias" stub
+    # is on PATH: it exits 0 while printing an install notice and cannot import
+    # yaml. We therefore functionally probe each candidate (must print a known
+    # token AND have the yaml module) before trusting it. If none qualifies we
+    # SKIP with a notice rather than emit false "invalid YAML" failures.
+    yaml_checker=""
+    if python3 -c 'import yaml; print("__pyyaml_ok__")' 2>/dev/null | grep -q '__pyyaml_ok__'; then
+      yaml_checker="python3"
+    elif python -c 'import yaml; print("__pyyaml_ok__")' 2>/dev/null | grep -q '__pyyaml_ok__'; then
+      yaml_checker="python"
+    elif ruby -ryaml -e 'puts "__ruby_ok__"' 2>/dev/null | grep -q '__ruby_ok__'; then
+      yaml_checker="ruby"
+    fi
+
+    if [[ -z "$yaml_checker" ]]; then
+      info "YAML validity skipped (no working python+pyyaml or ruby): ${#yaml_files[@]} file(s)"
+    else
+      yaml_bad=0
+      for f in "${yaml_files[@]}"; do
+        if [[ "$yaml_checker" == "ruby" ]]; then
+          if ! ruby -ryaml -e 'YAML.safe_load(File.read(ARGV[0]))' "$f" >/dev/null 2>&1; then
+            yaml_bad=$((yaml_bad + 1)); fail "invalid YAML: ${f#"$ROOT"/}"
+          fi
+        else
+          if ! "$yaml_checker" -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]))' "$f" >/dev/null 2>&1; then
+            yaml_bad=$((yaml_bad + 1)); fail "invalid YAML: ${f#"$ROOT"/}"
+          fi
+        fi
+      done
+      if [[ "$yaml_bad" -eq 0 ]]; then
+        pass "all ${#yaml_files[@]} YAML file(s) valid (via $yaml_checker)"
+      fi
+    fi
+  fi
+}
+
+# ===========================================================================
+# CHECK 5 - Deprecated agent names
+# ===========================================================================
+section "[5] Deprecated agent names (no live references in config or active doc refs)"
+{
+  # Scope (per spec): hooks/*.json, claude.json, commands/*.md, skills/*.md.
+  #
+  # IMPORTANT - false-positive avoidance:
+  #   The commands/*.md and skills/*.md files legitimately *document* the
+  #   deprecated names (migration guides, validator examples that literally
+  #   list old names). Flagging every prose mention would be wrong. We
+  #   therefore distinguish a real, LIVE reference from documentation:
+  #
+  #     * Structured config (hooks/*.json, claude.json):
+  #         flag a deprecated name used as a JSON string token  "<name>"
+  #         (this is how a hook/agent reference is actually encoded).
+  #     * Docs (commands/*.md, skills/*.md):
+  #         flag ONLY an ACTIVE reference, i.e.
+  #             agents/<name>.md            (a real prompt-file path)
+  #             subagent_type: <name>       (a real routing directive)
+  #             agent: <name> / "agent":"<name>"
+  #         Prose mentions ("replace maker-agent with ...") are NOT flagged.
+  #
+  # This yields zero false positives on the corrected tree while still
+  # catching any genuine resurrection of a dead agent name.
+
+  deprecated="$(fact_deprecated)"
+  ok=1
+
+  json_scope=("$ROOT/claude.json")
+  shopt -s nullglob
+  for f in "$FACTS_HOOKS_DIR"/*.json; do json_scope+=("$f"); done
+  doc_scope=("$ROOT"/commands/*.md "$ROOT"/skills/*.md)
+  shopt -u nullglob
+
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    esc="$(printf '%s' "$name" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')"
+
+    # Structured config: deprecated name as a JSON string token.
+    # EXCLUDE the consistency block's OWN canonical definition lines
+    # (deprecated_agent_names / hook_coverage_allowlist / model_shorthand_map),
+    # which legitimately enumerate these names. Those keys only ever appear in
+    # claude.json's consistency block, so filtering by key name is exact.
+    for f in "${json_scope[@]}"; do
+      [[ -f "$f" ]] || continue
+      hits="$(grep -nE "\"${esc}\"" "$f" 2>/dev/null \
+              | grep -vE '"(deprecated_agent_names|hook_coverage_allowlist|model_shorthand_map)"')"
+      if [[ -n "$hits" ]]; then
+        ok=0
+        fail "deprecated name '$name' used as config token in ${f#"$ROOT"/}:"
+        while IFS= read -r ln; do [[ -n "$ln" ]] && detail "$ln"; done <<< "$hits"
+      fi
+    done
+
+    # Docs: only ACTIVE references (path / routing directive), not prose.
+    active_re="agents/${esc}\.md|subagent_type[\"']?[[:space:]]*[:=][[:space:]]*[\"']?${esc}([\"', )]|\$)|\"agent\"[[:space:]]*:[[:space:]]*\"${esc}\"|(^|[[:space:](=])agent[[:space:]]*:[[:space:]]*${esc}([[:space:],)]|\$)"
+    for f in "${doc_scope[@]}"; do
+      [[ -f "$f" ]] || continue
+      hits="$(grep -nIE "$active_re" "$f" 2>/dev/null)"
+      if [[ -n "$hits" ]]; then
+        ok=0
+        fail "deprecated name '$name' used as an ACTIVE reference in ${f#"$ROOT"/}:"
+        while IFS= read -r ln; do [[ -n "$ln" ]] && detail "$ln"; done <<< "$hits"
+      fi
+    done
+  done <<< "$deprecated"
+
+  if [[ "$ok" -eq 1 ]]; then
+    ndep="$(printf '%s\n' "$deprecated" | grep -c .)"
+    pass "no live references to any of the $ndep deprecated names (prose docs ignored by design)"
+  fi
+}
+
+# ===========================================================================
+# CHECK 6 - Architecture / description strings
+# ===========================================================================
+section "[6] Architecture description strings match derived agent count + rosters"
+{
+  n_agents="$(printf '%s\n' "$AGENTS_SORTED" | grep -c .)"
+  ok=1
+
+  # 6a: claude.json .description contains "<n>-agent"
+  desc="$(_facts_jq -r '.description // ""' "$FACTS_CLAUDE_JSON")"
+  if printf '%s' "$desc" | grep -qE "(^|[^0-9])${n_agents}-agent([^0-9]|\$)"; then
+    pass "claude.json .description references '${n_agents}-agent'"
+  else
+    # Surface any OTHER N-agent value present so the failure is actionable.
+    found="$(printf '%s' "$desc" | grep -oE '[0-9]+-agent' | paste -sd, -)"
+    ok=0
+    fail "claude.json .description missing '${n_agents}-agent' (found: ${found:-none})"
+    detail "description: $desc"
+  fi
+
+  # 6b: core-hooks.json .description contains "<n>-agent"
+  core="$FACTS_HOOKS_DIR/core-hooks.json"
+  if [[ -f "$core" ]]; then
+    cdesc="$(_facts_jq -r '.description // ""' "$core")"
+    if printf '%s' "$cdesc" | grep -qE "(^|[^0-9])${n_agents}-agent([^0-9]|\$)"; then
+      pass "core-hooks.json .description references '${n_agents}-agent'"
+    else
+      found="$(printf '%s' "$cdesc" | grep -oE '[0-9]+-agent' | paste -sd, -)"
+      ok=0
+      fail "core-hooks.json .description missing '${n_agents}-agent' (found: ${found:-none})"
+      detail "description: $cdesc"
+    fi
+
+    # 6c: embedded rosters in core-hooks.json must reference only real agents,
+    #     and the 'all' roster must exactly equal fact_agents.
+    roster_keys="$(_facts_jq -r '.agent_group_definitions // {} | keys[]' "$core" 2>/dev/null)"
+    while IFS= read -r grp; do
+      [[ -z "$grp" ]] && continue
+      members="$(_facts_jq -r --arg g "$grp" '.agent_group_definitions[$g][]' "$core" 2>/dev/null | LC_ALL=C sort)"
+      # any member not a real agent?
+      bad="$(comm -23 <(printf '%s\n' "$members" | grep -v '^$' | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+      if [[ -n "$bad" ]]; then
+        ok=0
+        fail "core-hooks.json roster '$grp' references non-agent name(s):"
+        while IFS= read -r a; do [[ -n "$a" ]] && detail "stale/unknown in '$grp': $a"; done <<< "$bad"
+      fi
+      # the canonical 'all' roster must equal the full agent set
+      if [[ "$grp" == "all" ]]; then
+        only_roster="$(comm -23 <(printf '%s\n' "$members" | grep -v '^$' | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+        only_agents="$(comm -13 <(printf '%s\n' "$members" | grep -v '^$' | LC_ALL=C sort -u) <(printf '%s\n' "$AGENTS_SORTED"))"
+        if [[ -n "$only_roster" || -n "$only_agents" ]]; then
+          ok=0
+          fail "core-hooks.json 'all' roster does not equal the agent registry:"
+          while IFS= read -r a; do [[ -n "$a" ]] && detail "in 'all' but not an agent: $a"; done <<< "$only_roster"
+          while IFS= read -r a; do [[ -n "$a" ]] && detail "agent missing from 'all': $a"; done <<< "$only_agents"
+        else
+          pass "core-hooks.json 'all' roster exactly equals the $n_agents-agent registry"
+        fi
+      fi
+    done <<< "$roster_keys"
+  else
+    ok=0
+    fail "core-hooks.json not found at $core"
+  fi
+
+  [[ "$ok" -eq 1 ]] || true
+}
+
+# ===========================================================================
+# CHECK 8 - Stated-count scan (curated, high-signal, blocking)
+#   (Numbered 8 to match the spec; model parity WARNING is check 7 below.)
+# ===========================================================================
+section "[8] Stated-count scan (README/docs headline counts == derived values)"
+{
+  n_agents="$(fact_count agents)"
+  n_gates="$(fact_count quality_gates)"   # doc convention "Total Hooks"/"quality gates"
+
+  # Files to scan for headline counts.
+  scan_files=()
+  [[ -f "$ROOT/README.md" ]] && scan_files+=("$ROOT/README.md")
+  shopt -s nullglob
+  for f in "$ROOT"/commands/*.md "$ROOT"/skills/*.md; do scan_files+=("$f"); done
+  shopt -u nullglob
+
+  ok=1
+
+  # _scan_counts <regex> <which-number:first|last> <expected> <label>
+  #
+  # For each scan file, grep the regex with `-noE` (per-file => output is
+  # "<lineno>:<matched-text>", no path prefix, so the line number can never be
+  # mistaken for the stated count). The stated count is extracted from the
+  # MATCHED TEXT only (everything after the first ':'), taking the first or
+  # last number in the match. Any value != <expected> is a blocking failure.
+  #
+  # STRUCTURAL false-positive exclusions (the matched value is NOT a current
+  # declaration and is therefore ignored, not suppressed):
+  #   * grep-pattern lines: a count phrase that is the ARGUMENT of a grep call
+  #     (e.g. validator/migration scripts do `grep -q "11 specialized agents"`
+  #     to DETECT a stale old value). These search for a number; they don't
+  #     state one. Matches the spec's allowlisted historical "11 -> 19/20".
+  _scan_counts() {
+    local regex="$1" which="$2" expected="$3" label="$4"
+    local f rel out lineno match num srcline
+    for f in "${scan_files[@]}"; do
+      [[ -f "$f" ]] || continue
+      rel="${f#"$ROOT"/}"
+      # -o => only matched text; -n => line number; -I => skip binary.
+      out="$(grep -noIE "$regex" "$f" 2>/dev/null)" || true
+      [[ -z "$out" ]] && continue
+      while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        lineno="${line%%:*}"          # leading line number
+        match="${line#*:}"            # matched text only (after first colon)
+        # Pull the full source line for context-based exclusions.
+        srcline="$(sed -n "${lineno}p" "$f")"
+        # Exclude grep-pattern contexts (detecting an old value, not stating one).
+        if printf '%s' "$srcline" | grep -qE '\bgrep\b'; then
+          continue
+        fi
+        if [[ "$which" == "last" ]]; then
+          num="$(printf '%s' "$match" | grep -oE '[0-9]+' | tail -1)"
+        else
+          num="$(printf '%s' "$match" | grep -oE '[0-9]+' | head -1)"
+        fi
+        if [[ "$num" != "$expected" ]]; then
+          ok=0
+          fail "$label: stated '$num' != derived $expected ($rel:$lineno)"
+          detail "$match"
+        fi
+      done <<< "$out"
+    done
+  }
+
+  # ---- 8a: "<N> specialized agents" headline (case-insensitive) ------------
+  # High-signal ONLY: a number immediately followed by "specialized agents".
+  # This deliberately does NOT match the legitimate non-derived numbers, which
+  # are therefore never even examined (structural exclusion, not suppression):
+  #   - "19 agent-specific" / "19 required" / "Agent-Specific: 19" / "19 of 20"
+  #     / "19/20" / "X/20" coverage ratios
+  #   - historical "11 -> 19" / "11 agents" migration narrative
+  #   - subtotals like "26 framework-wide", "1 framework-wide gate"
+  #   - "5 MCP servers", "14 Skills", "6 commands", "v3.0.0", dates, %, head -20
+  _scan_counts '[0-9]+ [Ss]pecialized [Aa]gents' first "$n_agents" "agent count"
+
+  # ---- 8b: "<N> Quality Gates" / "<N> quality gates" -----------------------
+  _scan_counts '[0-9]+ [Qq]uality [Gg]ates' first "$n_gates" "quality-gate count"
+
+  # ---- 8c: "Total Hooks: <N>" / "Total Hooks:** <N>" -----------------------
+  _scan_counts 'Total Hooks:\*{0,2} ?[0-9]+' last "$n_gates" "Total Hooks count"
+
+  # ---- 8d: 'wc -l  # Should show <N>' agent-file assertion ------------------
+  # README documents `ls -1 agents/*.md | wc -l  # Should show <N>`.
+  _scan_counts 'Should show [0-9]+' last "$n_agents" "documented agent-file count"
+
+  if [[ "$ok" -eq 1 ]]; then
+    pass "all high-signal stated counts match derived values (agents=$n_agents, gates=$n_gates)"
+  fi
+}
+
+# ===========================================================================
+# CHECK 7 - Model parity (NON-BLOCKING WARNING)
+# ===========================================================================
+section "[7] Model parity (agents/<a>.md frontmatter model: == claude.json model)  [WARNING]"
+{
+  mismatches=0 checked=0 unresolved=0
+  while IFS=$'\t' read -r agent model_id; do
+    [[ -z "$agent" ]] && continue
+    md="$FACTS_AGENTS_DIR/$agent.md"
+    [[ -f "$md" ]] || continue
+    # frontmatter model: value (first occurrence)
+    fm="$(grep -m1 -E '^model:[[:space:]]*' "$md" | sed -E 's/^model:[[:space:]]*//; s/[[:space:]]+$//; s/^["'\'']//; s/["'\'']$//')"
+    [[ -z "$fm" ]] && continue
+    checked=$((checked + 1))
+    # Resolve shorthand -> full id (if it IS a shorthand); otherwise compare raw.
+    resolved="$(fact_model_shorthand "$fm" 2>/dev/null || true)"
+    if [[ -z "$resolved" ]]; then
+      # Not a known shorthand; maybe it's already a full id.
+      resolved="$fm"
+      if ! printf '%s\n' "$resolved" | grep -qE '^claude-'; then
+        unresolved=$((unresolved + 1))
+        warn "$agent: frontmatter model '$fm' is not a known shorthand or full id"
+        continue
+      fi
+    fi
+    if [[ "$resolved" != "$model_id" ]]; then
+      mismatches=$((mismatches + 1))
+      warn "$agent: frontmatter '$fm' -> '$resolved' != claude.json '$model_id'"
+    fi
+  done <<< "$(fact_models)"
+
+  if [[ "$mismatches" -eq 0 && "$unresolved" -eq 0 ]]; then
+    pass "all $checked agent frontmatter models agree with claude.json"
+  else
+    info "model parity is advisory: $mismatches mismatch(es), $unresolved unresolved of $checked checked (non-blocking)"
+  fi
+}
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+printf '\n%s================================================%s\n' "$C_CYN" "$C_NC"
+if [[ "$BLOCKING_FAILURES" -eq 0 ]]; then
+  printf '%s  RESULT: PASS%s  (blocking failures: 0, warnings: %s)\n' "$C_GRN" "$C_NC" "$WARNINGS"
+  printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+  exit 0
+else
+  printf '%s  RESULT: FAIL%s  (blocking failures: %s, warnings: %s)\n' "$C_RED" "$C_NC" "$BLOCKING_FAILURES" "$WARNINGS"
+  printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+  exit 1
+fi

--- a/scripts/validate-framework.sh
+++ b/scripts/validate-framework.sh
@@ -1,8 +1,31 @@
-#!/bin/bash
-# validate-framework.sh - Comprehensive framework validation script
-# Validates the Claude Code CLI Agentic Framework integrity
+#!/usr/bin/env bash
+# validate-framework.sh - Comprehensive framework validation (dynamic).
+#
+# Validates the Claude Code CLI Agentic Framework integrity. All "truth" is
+# DERIVED at runtime from claude.json + the filesystem via the shared facts
+# layer (scripts/lib/facts.sh): there is NO frozen EXPECTED_AGENTS array and NO
+# hardcoded agent count anywhere in this script.
+#
+# Structure:
+#   Steps 1-2 here perform lightweight structural checks (core files +
+#   directories). The deep consistency battery (registry<->fs parity, category
+#   partition, hook coverage, JSON/YAML validity, deprecated names, arch
+#   strings, stated-count scan, model parity) is delegated to the single source
+#   of truth, validate-consistency.sh, so the two never drift apart.
 
-set -e
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/facts.sh
+source "$SCRIPT_DIR/lib/facts.sh"
+
+ROOT="$FACTS_REPO_ROOT"
+
+if [[ -t 1 ]]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+else
+  RED=""; GREEN=""; YELLOW=""; NC=""
+fi
 
 echo "🔍 Claude Code CLI Agentic Framework Validator"
 echo "================================================"
@@ -11,191 +34,62 @@ echo ""
 ERRORS=0
 WARNINGS=0
 
-# Color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Expected agents (18 total)
-EXPECTED_AGENTS=(
-  "rust-expert"
-  "csharp-expert"
-  "go-expert"
-  "java-expert"
-  "python-expert"
-  "typescript-expert"
-  "bash-expert"
-  "powershell-expert"
-  "database-specialist"
-  "frontend-specialist"
-  "security-specialist"
-  "uiux-specialist"
-  "devops-orchestrator"
-  "system-architect"
-  "comprehensive-analyst"
-  "code-review-gatekeeper"
-  "technical-docs-writer"
-  "product-owner"
-)
-
-# Old agent names that should NOT exist
-OLD_AGENTS=(
-  "plan-agent"
-  "reader-agent"
-  "maker-agent"
-  "security-agent"
-  "test-agent"
-  "docs-agent"
-  "debug-agent"
-  "rust-systems-expert"
-)
+# Derived facts (no hardcoded values).
+N_AGENTS="$(fact_agents | grep -c . || true)"
 
 echo "📋 Step 1: Validating Core Files"
 echo "--------------------------------"
 
-# Check CLAUDE.md
-if [ -f "CLAUDE.md" ]; then
-  echo -e "${GREEN}✅${NC} CLAUDE.md found"
-else
-  echo -e "${RED}❌${NC} CLAUDE.md missing"
-  ((ERRORS++))
-fi
-
-# Check claude.json
-if [ -f "claude.json" ]; then
-  echo -e "${GREEN}✅${NC} claude.json found"
-
-  # Validate JSON syntax
-  if command -v jq &> /dev/null; then
-    if jq empty claude.json 2>/dev/null; then
-      echo -e "${GREEN}✅${NC} claude.json has valid JSON syntax"
-    else
-      echo -e "${RED}❌${NC} claude.json has invalid JSON syntax"
-      ((ERRORS++))
-    fi
+for core in CLAUDE.md claude.json; do
+  if [[ -f "$ROOT/$core" ]]; then
+    echo -e "${GREEN}✅${NC} $core found"
+  else
+    echo -e "${RED}❌${NC} $core missing"
+    ERRORS=$((ERRORS + 1))
   fi
-else
-  echo -e "${RED}❌${NC} claude.json missing"
-  ((ERRORS++))
+done
+
+if [[ -f "$ROOT/claude.json" ]]; then
+  if jq empty "$ROOT/claude.json" >/dev/null 2>&1; then
+    echo -e "${GREEN}✅${NC} claude.json has valid JSON syntax"
+  else
+    echo -e "${RED}❌${NC} claude.json has invalid JSON syntax"
+    ERRORS=$((ERRORS + 1))
+  fi
 fi
 
-# Check README.md
-if [ -f "README.md" ]; then
+if [[ -f "$ROOT/README.md" ]]; then
   echo -e "${GREEN}✅${NC} README.md found"
 else
   echo -e "${YELLOW}⚠️${NC}  README.md missing"
-  ((WARNINGS++))
+  WARNINGS=$((WARNINGS + 1))
 fi
 
 echo ""
 echo "📁 Step 2: Validating Directories"
 echo "--------------------------------"
 
-# Check required directories
-for dir in "agents" "commands" "hooks" "shared" "skills"; do
-  if [ -d "$dir" ]; then
+for dir in agents commands hooks shared skills; do
+  if [[ -d "$ROOT/$dir" ]]; then
     echo -e "${GREEN}✅${NC} $dir/ directory exists"
   else
     echo -e "${RED}❌${NC} $dir/ directory missing"
-    ((ERRORS++))
+    ERRORS=$((ERRORS + 1))
   fi
 done
 
 echo ""
-echo "🤖 Step 3: Validating Agents (18 expected)"
-echo "----------------------------------------"
-
-AGENT_COUNT=0
-for agent in "${EXPECTED_AGENTS[@]}"; do
-  if [ -f "agents/${agent}.md" ]; then
-    echo -e "${GREEN}✅${NC} ${agent}.md"
-    ((AGENT_COUNT++))
-  else
-    echo -e "${RED}❌${NC} ${agent}.md MISSING"
-    ((ERRORS++))
-  fi
-done
-
+echo "🤖 Step 3: Deep Consistency Checks (delegated to validate-consistency.sh)"
+echo "------------------------------------------------------------------------"
+echo "Expected agents (derived from claude.json): ${N_AGENTS}"
 echo ""
-echo "Agent count: $AGENT_COUNT / 18"
 
-if [ $AGENT_COUNT -eq 18 ]; then
-  echo -e "${GREEN}✅${NC} All 18 agents present"
+# Delegate the authoritative, dynamic checks to the single source of truth.
+if bash "$SCRIPT_DIR/validate-consistency.sh"; then
+  CONSISTENCY_OK=1
 else
-  echo -e "${RED}❌${NC} Expected 18 agents, found $AGENT_COUNT"
-  ((ERRORS++))
-fi
-
-echo ""
-echo "🚫 Step 4: Checking for Old Agent Names"
-echo "--------------------------------------"
-
-OLD_FOUND=0
-for old_agent in "${OLD_AGENTS[@]}"; do
-  # Check in claude.json
-  if grep -q "\"$old_agent\"" claude.json 2>/dev/null; then
-    echo -e "${RED}❌${NC} Found old agent name '$old_agent' in claude.json"
-    ((ERRORS++))
-    ((OLD_FOUND++))
-  fi
-
-  # Check in hooks
-  if grep -r "\"$old_agent\"" hooks/ 2>/dev/null | grep -v "archive" >/dev/null; then
-    echo -e "${RED}❌${NC} Found old agent name '$old_agent' in hooks/"
-    ((ERRORS++))
-    ((OLD_FOUND++))
-  fi
-done
-
-if [ $OLD_FOUND -eq 0 ]; then
-  echo -e "${GREEN}✅${NC} No old agent names found"
-fi
-
-echo ""
-echo "🪝 Step 5: Validating Hooks"
-echo "-------------------------"
-
-HOOK_COUNT=$(find hooks/ -maxdepth 1 -name "*.json" -o -name "*.yaml" 2>/dev/null | wc -l)
-echo "Found $HOOK_COUNT hook files"
-
-if [ $HOOK_COUNT -gt 0 ]; then
-  echo -e "${GREEN}✅${NC} Hook files present"
-
-  # Validate JSON syntax if jq is available
-  if command -v jq &> /dev/null; then
-    JSON_ERRORS=0
-    for file in hooks/*.json; do
-      if [ -f "$file" ]; then
-        if ! jq empty "$file" 2>/dev/null; then
-          echo -e "${RED}❌${NC} Invalid JSON in $(basename "$file")"
-          ((ERRORS++))
-          ((JSON_ERRORS++))
-        fi
-      fi
-    done
-
-    if [ $JSON_ERRORS -eq 0 ]; then
-      echo -e "${GREEN}✅${NC} All JSON hook files have valid syntax"
-    fi
-  fi
-else
-  echo -e "${YELLOW}⚠️${NC}  No hook files found"
-  ((WARNINGS++))
-fi
-
-echo ""
-echo "🎯 Step 6: Validating Skills"
-echo "---------------------------"
-
-SKILL_COUNT=$(find skills/ -maxdepth 1 -name "*.md" 2>/dev/null | wc -l)
-echo "Found $SKILL_COUNT skill files"
-
-if [ $SKILL_COUNT -gt 0 ]; then
-  echo -e "${GREEN}✅${NC} Skill files present"
-else
-  echo -e "${YELLOW}⚠️${NC}  No skill files found"
-  ((WARNINGS++))
+  CONSISTENCY_OK=0
+  ERRORS=$((ERRORS + 1))
 fi
 
 echo ""
@@ -203,16 +97,14 @@ echo "📊 Validation Summary"
 echo "===================="
 echo ""
 
-if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+if [[ "$ERRORS" -eq 0 && "$WARNINGS" -eq 0 ]]; then
   echo -e "${GREEN}🎉 PERFECT!${NC} Framework validation passed with no errors or warnings"
   echo ""
   echo "✅ All core files present"
-  echo "✅ All 18 agents configured"
-  echo "✅ No old agent names found"
-  echo "✅ All hooks valid"
-  echo "✅ Skills system in place"
+  echo "✅ All ${N_AGENTS} agents consistent (registry == filesystem)"
+  echo "✅ Consistency battery passed"
   exit 0
-elif [ $ERRORS -eq 0 ]; then
+elif [[ "$ERRORS" -eq 0 ]]; then
   echo -e "${YELLOW}⚠️  WARNINGS FOUND${NC}"
   echo "Errors: 0"
   echo "Warnings: $WARNINGS"

--- a/scripts/validate-framework.sh
+++ b/scripts/validate-framework.sh
@@ -85,10 +85,7 @@ echo "Expected agents (derived from claude.json): ${N_AGENTS}"
 echo ""
 
 # Delegate the authoritative, dynamic checks to the single source of truth.
-if bash "$SCRIPT_DIR/validate-consistency.sh"; then
-  CONSISTENCY_OK=1
-else
-  CONSISTENCY_OK=0
+if ! bash "$SCRIPT_DIR/validate-consistency.sh"; then
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/scripts/validate-hooks.sh
+++ b/scripts/validate-hooks.sh
@@ -8,6 +8,9 @@
 # names or counts remain.
 
 set -uo pipefail
+# Force C collation so `comm` matches the facts layer's `LC_ALL=C sort` (else
+# bogus missing/orphan results under a non-C locale).
+export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/facts.sh

--- a/scripts/validate-hooks.sh
+++ b/scripts/validate-hooks.sh
@@ -36,11 +36,15 @@ DEP_FOUND=0
 
 while IFS= read -r name; do
   [[ -z "$name" ]] && continue
-  esc="$(printf '%s' "$name" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')"
+  # hooks/*.json carry no .consistency block, so the deprecated name only ever
+  # appears here as a genuine JSON string token. Match the literal token with
+  # fixed-string grep (-F): this is correct for a JSON literal and immune to
+  # regex metacharacters in the name (the previous sed-based escaper emitted a
+  # literal '&' on this platform and could miss metachar names -> false negatives).
   shopt -s nullglob
   for f in "$HOOKS_DIR"/*.json; do
     case "$f" in *archive*) continue;; esac
-    hits="$(grep -nE "\"${esc}\"" "$f" 2>/dev/null)"
+    hits="$(grep -nF "\"$name\"" "$f" 2>/dev/null)"
     if [[ -n "$hits" ]]; then
       echo "❌ Found deprecated name '$name' in $(basename "$f"):"
       while IFS= read -r ln; do [[ -n "$ln" ]] && echo "     $ln"; done <<< "$hits"

--- a/scripts/validate-hooks.sh
+++ b/scripts/validate-hooks.sh
@@ -1,5 +1,20 @@
-#!/bin/bash
-# validate-hooks.sh - Hook consistency validation
+#!/usr/bin/env bash
+# validate-hooks.sh - Hook consistency validation (dynamic).
+#
+# Keeps the original behavior (deprecated-name scan + JSON syntax validity) but
+# sources the deprecated list from the shared facts layer instead of hardcoding
+# it, and adds a hook-coverage parity check (every non-allowlisted agent has a
+# {agent}-validation.json; no orphan validation hooks). No hardcoded agent
+# names or counts remain.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/facts.sh
+source "$SCRIPT_DIR/lib/facts.sh"
+
+ROOT="$FACTS_REPO_ROOT"
+HOOKS_DIR="$FACTS_HOOKS_DIR"
 
 echo "🪝 Hook Validation Check"
 echo "========================"
@@ -7,52 +22,116 @@ echo ""
 
 ERRORS=0
 
-# Old agent names that should NOT appear in hooks
-OLD_AGENTS=(
-  "maker-agent"
-  "test-agent"
-  "debug-agent"
-  "reader-agent"
-  "plan-agent"
-  "security-agent"
-  "docs-agent"
-  "rust-systems-expert"
-)
-
-echo "Checking for old agent references..."
+# ---------------------------------------------------------------------------
+# 1. Deprecated agent references in hooks/*.json
+#    The deprecated list is DERIVED from claude.json .consistency, not frozen.
+#    We match deprecated names as JSON string tokens ("name") inside hook json,
+#    excluding any archive paths.
+# ---------------------------------------------------------------------------
+echo "Checking for deprecated agent references in hooks/..."
 echo ""
 
-for old_agent in "${OLD_AGENTS[@]}"; do
-  if grep -r "\"$old_agent\"" hooks/ 2>/dev/null | grep -v "archive" | grep -q .; then
-    echo "❌ Found '$old_agent' in:"
-    grep -r "\"$old_agent\"" hooks/ | grep -v "archive"
-    ((ERRORS++))
-  fi
-done
+DEPRECATED="$(fact_deprecated)"
+DEP_FOUND=0
 
-if [ $ERRORS -eq 0 ]; then
-  echo "✅ No old agent references found"
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  esc="$(printf '%s' "$name" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')"
+  shopt -s nullglob
+  for f in "$HOOKS_DIR"/*.json; do
+    case "$f" in *archive*) continue;; esac
+    hits="$(grep -nE "\"${esc}\"" "$f" 2>/dev/null)"
+    if [[ -n "$hits" ]]; then
+      echo "❌ Found deprecated name '$name' in $(basename "$f"):"
+      while IFS= read -r ln; do [[ -n "$ln" ]] && echo "     $ln"; done <<< "$hits"
+      DEP_FOUND=$((DEP_FOUND + 1))
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+  shopt -u nullglob
+done <<< "$DEPRECATED"
+
+if [[ "$DEP_FOUND" -eq 0 ]]; then
+  ndep="$(printf '%s\n' "$DEPRECATED" | grep -c . || true)"
+  echo "✅ No deprecated agent references found (checked ${ndep} names)"
 fi
 
+# ---------------------------------------------------------------------------
+# 2. Hook-coverage parity
+#    Every agent NOT on the allowlist must have hooks/<agent>-validation.json;
+#    every *-validation.json must map to a real agent (no orphan).
+# ---------------------------------------------------------------------------
+echo ""
+echo "Checking hook coverage parity..."
+echo ""
+
+AGENTS="$(fact_agents)"
+ALLOWLIST="$(fact_allowlist)"
+REQUIRED="$(comm -23 <(printf '%s\n' "$AGENTS") <(printf '%s\n' "$ALLOWLIST"))"
+
+shopt -s nullglob
+EXISTING=""
+for f in "$HOOKS_DIR"/*-validation.json; do
+  b="$(basename "$f")"
+  EXISTING+="${b%-validation.json}"$'\n'
+done
+shopt -u nullglob
+EXISTING_SORTED="$(printf '%s' "$EXISTING" | grep -v '^$' | LC_ALL=C sort)"
+
+COV_ERRORS=0
+
+NO_HOOK="$(comm -23 <(printf '%s\n' "$REQUIRED") <(printf '%s\n' "$EXISTING_SORTED"))"
+if [[ -n "$NO_HOOK" ]]; then
+  while IFS= read -r a; do
+    [[ -z "$a" ]] && continue
+    echo "❌ Missing hooks/${a}-validation.json for agent '${a}'"
+    COV_ERRORS=$((COV_ERRORS + 1))
+    ERRORS=$((ERRORS + 1))
+  done <<< "$NO_HOOK"
+fi
+
+ORPHAN_HOOK="$(comm -23 <(printf '%s\n' "$EXISTING_SORTED") <(printf '%s\n' "$AGENTS"))"
+if [[ -n "$ORPHAN_HOOK" ]]; then
+  while IFS= read -r a; do
+    [[ -z "$a" ]] && continue
+    echo "❌ Orphan hooks/${a}-validation.json maps to no registered agent"
+    COV_ERRORS=$((COV_ERRORS + 1))
+    ERRORS=$((ERRORS + 1))
+  done <<< "$ORPHAN_HOOK"
+fi
+
+if [[ "$COV_ERRORS" -eq 0 ]]; then
+  nreq="$(printf '%s\n' "$REQUIRED" | grep -c . || true)"
+  echo "✅ Hook coverage complete: all ${nreq} required agents covered; no orphans"
+  if [[ -n "$ALLOWLIST" ]]; then
+    while IFS= read -r a; do
+      [[ -z "$a" ]] && continue
+      echo "ℹ️  allowlisted (no per-agent hook required): ${a}"
+    done <<< "$ALLOWLIST"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. JSON syntax validity for all hooks/*.json
+# ---------------------------------------------------------------------------
 echo ""
 echo "Validating JSON syntax..."
 echo ""
 
-if command -v jq &> /dev/null; then
+if command -v jq >/dev/null 2>&1; then
   JSON_ERRORS=0
-  for file in hooks/*.json; do
-    if [ -f "$file" ]; then
-      if jq empty "$file" 2>/dev/null; then
-        echo "✅ $(basename "$file")"
-      else
-        echo "❌ $(basename "$file") - INVALID JSON"
-        ((JSON_ERRORS++))
-        ((ERRORS++))
-      fi
+  shopt -s nullglob
+  for f in "$HOOKS_DIR"/*.json; do
+    if jq empty "$f" >/dev/null 2>&1; then
+      echo "✅ $(basename "$f")"
+    else
+      echo "❌ $(basename "$f") - INVALID JSON"
+      JSON_ERRORS=$((JSON_ERRORS + 1))
+      ERRORS=$((ERRORS + 1))
     fi
   done
-
-  if [ $JSON_ERRORS -eq 0 ]; then
+  shopt -u nullglob
+  if [[ "$JSON_ERRORS" -eq 0 ]]; then
     echo ""
     echo "✅ All JSON files valid"
   fi
@@ -62,10 +141,10 @@ fi
 
 echo ""
 echo "================================"
-if [ $ERRORS -eq 0 ]; then
+if [[ "$ERRORS" -eq 0 ]]; then
   echo "✅ Hook validation passed"
   exit 0
 else
-  echo "❌ Found $ERRORS errors"
+  echo "❌ Found $ERRORS error(s)"
   exit 1
 fi

--- a/tests/consistency.test.sh
+++ b/tests/consistency.test.sh
@@ -328,8 +328,6 @@ section "[10] Idempotency: generate-docs.sh --write on a clean copy is a no-op"
 {
   copy="$(make_copy)"
   la="$copy/commands/list-agents.md"
-  before="$(jq -nr --arg s "$(tr -d '\r' < "$la")" '$s | @base64' 2>/dev/null)"
-  # Fallback hash if jq @base64 path is awkward: compare raw bytes via cmp later.
   cp "$la" "$copy/.la.before"
   run_generate "$copy" --write
   assert_rc_zero "generate-docs.sh --write succeeds on a clean copy"
@@ -342,7 +340,6 @@ section "[10] Idempotency: generate-docs.sh --write on a clean copy is a no-op"
   run_generate "$copy" --check
   assert_rc_zero "--check confirms blocks fresh after idempotent --write"
   rm -rf "$copy"
-  unset before
 }
 
 # ===========================================================================

--- a/tests/consistency.test.sh
+++ b/tests/consistency.test.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# consistency.test.sh - Portable, self-contained test harness for the anti-drift
+# consistency system (Phase A+B: scripts/lib/*.sh, scripts/validate-consistency.sh,
+# scripts/generate-docs.sh).
+#
+# WHY plain bash (not bats): this must run unmodified on the developer's Windows
+# machine (Cygwin/Git-bash) AND on ubuntu-latest CI with nothing but bash + jq.
+#
+# ISOLATION CONTRACT (the real working tree is NEVER mutated):
+#   Each test case operates on its own throwaway copy of the repo:
+#     1. `cp -r` every top-level entry EXCEPT .git into a fresh `mktemp -d` dir.
+#        The copy is therefore a detached, NON-git tree (a `cp -r` copy must be
+#        validated as such; .git is skipped both for correctness and speed).
+#     2. Mutate ONLY the copy (inject a defect, or leave it clean).
+#     3. Run the COPIED scripts/validate-consistency.sh / generate-docs.sh against
+#        the copy, with FRAMEWORK_ROOT pinned to the copy root.
+#     4. Assert the exit code / message.
+#     5. Remove the temp dir (a per-run trap also sweeps any leftovers).
+#
+#   FRAMEWORK_ROOT is required, not optional: `git rev-parse` would otherwise
+#   resolve the copy's root to whatever git tree the temp dir happens to live in
+#   (e.g. when TMPDIR is inside a checkout), silently testing the WRONG tree.
+#   facts.sh honours FRAMEWORK_ROOT above git, so pinning it guarantees every
+#   assertion is made against the isolated copy.
+#
+# Usage:
+#   bash tests/consistency.test.sh
+#   echo "exit=$?"      # 0 = all cases passed, 1 = at least one failed
+#
+# Requirements: bash, jq, cp, mktemp, awk, grep.
+
+set -uo pipefail
+# NOTE: -e is intentionally NOT set. We run every case and aggregate results; a
+# single failing assertion must not abort the whole suite.
+
+# --- locate the repo under test --------------------------------------------
+# The harness lives at <repo>/tests/consistency.test.sh, so the source repo is
+# one level up from this script's directory. Resolved script-relative so the
+# suite can be invoked from any CWD.
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_REPO="$(cd "$TEST_DIR/.." && pwd)"
+
+# --- pin the bash interpreter (portability + Windows safety) ----------------
+# Invoke every copied script with the SAME bash that is running this harness,
+# and put that bash's directory first on PATH so any nested `bash ...` call
+# inside the scripts (e.g. validate-consistency.sh check 11 -> generate-docs.sh)
+# resolves to the identical interpreter. On a Windows box with several bash
+# flavors on PATH (Cygwin, Git-for-Windows, the WindowsApps stub) a mixed
+# Cygwin+Git-bash pipeline can deadlock on process substitution; pinning one
+# flavor avoids that. On Linux/CI this is simply /usr/bin/bash either way.
+BASH_BIN="${BASH:-bash}"
+if [[ -x "$BASH_BIN" ]]; then
+  PATH="$(dirname "$BASH_BIN"):$PATH"
+  export PATH
+fi
+
+# --- output helpers ---------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'; C_YEL=$'\033[1;33m'
+  C_CYN=$'\033[0;36m'; C_NC=$'\033[0m'
+else
+  C_RED=""; C_GRN=""; C_YEL=""; C_CYN=""; C_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_PASS=0
+TESTS_FAIL=0
+
+# Track every temp dir we create so the global trap can sweep them even if a
+# case dies unexpectedly. The real tree never appears in here.
+declare -a __TMP_DIRS=()
+
+cleanup_all() {
+  local d
+  for d in "${__TMP_DIRS[@]:-}"; do
+    [[ -n "${d:-}" && -d "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup_all EXIT INT TERM
+
+# --- copy helper ------------------------------------------------------------
+# make_copy -> prints the path to a fresh, isolated, non-git copy of the repo.
+# The caller mutates and runs scripts against the returned path.
+#
+# We copy every top-level entry EXCEPT .git. Skipping .git is deliberate:
+#   * the copy must be a detached, NON-git tree (exercises facts.sh's non-git
+#     root-resolution fallback), so .git would be removed anyway;
+#   * copying .git (thousands of tiny objects) is by far the slowest part of a
+#     `cp -r` under Cygwin/Windows - excluding it keeps each case fast.
+# Dotfiles that matter (.gitattributes, .mcp.json, .claude/, etc.) ARE copied;
+# only .git (and the . / .. pseudo-entries) are skipped.
+make_copy() {
+  local dst entry base
+  dst="$(mktemp -d "${TMPDIR:-/tmp}/consistency-test.XXXXXX")" || {
+    printf 'FATAL: mktemp failed\n' >&2
+    exit 2
+  }
+  __TMP_DIRS+=("$dst")
+  shopt -s dotglob nullglob
+  for entry in "$SRC_REPO"/*; do
+    base="$(basename "$entry")"
+    [[ "$base" == ".git" ]] && continue
+    cp -r "$entry" "$dst/"
+  done
+  shopt -u dotglob nullglob
+  printf '%s\n' "$dst"
+}
+
+# --- script runners (pin FRAMEWORK_ROOT to the copy) ------------------------
+# run_validate <copy-root> -> runs the COPIED validator against the copy.
+#   Captures combined stdout+stderr into $RUN_OUT and the exit code into $RUN_RC.
+RUN_OUT=""
+RUN_RC=0
+run_validate() {
+  local root="$1"
+  RUN_OUT="$(FRAMEWORK_ROOT="$root" "$BASH_BIN" "$root/scripts/validate-consistency.sh" 2>&1)"
+  RUN_RC=$?
+}
+# run_generate <copy-root> <mode...> -> runs the COPIED generator against the copy.
+run_generate() {
+  local root="$1"; shift
+  RUN_OUT="$(FRAMEWORK_ROOT="$root" "$BASH_BIN" "$root/scripts/generate-docs.sh" "$@" 2>&1)"
+  RUN_RC=$?
+}
+
+# --- assertions -------------------------------------------------------------
+# Every assertion records pass/fail and prints a one-line verdict. They never
+# exit; the suite always runs to completion.
+_pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASS=$((TESTS_PASS + 1)); printf '  %sPASS%s  %s\n' "$C_GRN" "$C_NC" "$1"; }
+_fail() {
+  TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAIL=$((TESTS_FAIL + 1))
+  printf '  %sFAIL%s  %s\n' "$C_RED" "$C_NC" "$1"
+  [[ -n "${2:-}" ]] && printf '        %s\n' "$2"
+}
+
+assert_rc_zero() {
+  local label="$1"
+  if [[ "$RUN_RC" -eq 0 ]]; then _pass "$label (exit 0)"
+  else _fail "$label" "expected exit 0, got $RUN_RC"; fi
+}
+assert_rc_nonzero() {
+  local label="$1"
+  if [[ "$RUN_RC" -ne 0 ]]; then _pass "$label (exit $RUN_RC)"
+  else _fail "$label" "expected non-zero exit, got 0"; fi
+}
+# assert_out_contains <label> <needle>
+assert_out_contains() {
+  local label="$1" needle="$2"
+  if printf '%s' "$RUN_OUT" | grep -qF -- "$needle"; then _pass "$label"
+  else _fail "$label" "expected output to contain: $needle"; fi
+}
+
+section() { printf '\n%s%s%s\n' "$C_CYN" "$1" "$C_NC"; }
+
+# ===========================================================================
+printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+printf '%s  Anti-Drift Consistency Test Harness%s\n' "$C_CYN" "$C_NC"
+printf '%s  source repo: %s%s\n' "$C_CYN" "$SRC_REPO" "$C_NC"
+printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+
+# --- preflight --------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%sFATAL%s jq is required but not installed.\n' "$C_RED" "$C_NC" >&2
+  exit 2
+fi
+
+# ===========================================================================
+# CASE 1 - Happy path: unmodified copy validates clean.
+# ===========================================================================
+section "[1] Happy path: unmodified copy -> validate-consistency.sh exits 0"
+{
+  copy="$(make_copy)"
+  run_validate "$copy"
+  assert_rc_zero "unmodified copy passes validation"
+  assert_out_contains "validator reports RESULT: PASS" "RESULT: PASS"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 2 - Missing agent .md: registry parity must fail.
+# ===========================================================================
+section "[2] Missing agent: delete agents/go-expert.md -> non-zero (registry parity)"
+{
+  copy="$(make_copy)"
+  rm -f "$copy/agents/go-expert.md"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when a registered agent has no .md"
+  assert_out_contains "reports missing-md for go-expert" "missing-md: go-expert"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 3 - Orphan agent file not in claude.json.
+# ===========================================================================
+section "[3] Orphan agent file: add agents/zzz-expert.md (unregistered) -> non-zero"
+{
+  copy="$(make_copy)"
+  printf -- '---\nname: zzz-expert\nmodel: opus\n---\nOrphan.\n' > "$copy/agents/zzz-expert.md"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails on an orphan agents/*.md"
+  assert_out_contains "reports orphan-md for zzz-expert" "orphan-md: zzz-expert"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 4 - Category partition break: remove an agent from agent_categories.
+# ===========================================================================
+section "[4] Category partition break: drop an agent from agent_categories -> non-zero"
+{
+  copy="$(make_copy)"
+  # Pick the first agent that is currently assigned to some category, then
+  # remove it from every category list. The agent stays registered + has its
+  # .md, so the ONLY break is the category partition (uncategorized agent).
+  victim="$(jq -r '.agent_categories | to_entries[0].value[0]' "$copy/claude.json")"
+  jq --arg v "$victim" '
+    .agent_categories |= with_entries(.value |= map(select(. != $v)))
+  ' "$copy/claude.json" > "$copy/claude.json.tmp" && mv "$copy/claude.json.tmp" "$copy/claude.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when an agent is in no category"
+  assert_out_contains "reports uncategorized agent ($victim)" "uncategorized: $victim"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 5 - Missing validation hook for a non-allowlisted agent.
+# ===========================================================================
+section "[5] Missing hook: rm hooks/rust-expert-validation.json -> non-zero (hook coverage)"
+{
+  copy="$(make_copy)"
+  rm -f "$copy/hooks/rust-expert-validation.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when a required agent has no validation hook"
+  assert_out_contains "reports missing-hook for rust-expert" "missing-hook: rust-expert"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 6 - Allowlist works: an allowlisted agent (peer-review-critic) needs no
+#          hook, and a clean copy must still pass. Guards against a regression
+#          that would force a per-agent hook onto allowlisted agents.
+# ===========================================================================
+section "[6] Allowlist: allowlisted agent (no hook) still passes -> exit 0"
+{
+  copy="$(make_copy)"
+  # Sanity: the allowlist is non-empty and the allowlisted agent has NO hook on
+  # disk (so a passing run proves the allowlist exemption is honoured).
+  al="$(FRAMEWORK_ROOT="$copy" "$BASH_BIN" -c 'source "$0/scripts/lib/facts.sh"; fact_allowlist' "$copy")"
+  if [[ -z "$al" ]]; then
+    _fail "allowlist is non-empty" "fact_allowlist returned nothing"
+  else
+    _pass "allowlist is non-empty ($(printf '%s' "$al" | tr '\n' ' '))"
+  fi
+  # Confirm at least one allowlisted agent has no validation hook file.
+  exempt_no_hook=""
+  while IFS= read -r a; do
+    [[ -z "$a" ]] && continue
+    [[ -f "$copy/hooks/${a}-validation.json" ]] || { exempt_no_hook="$a"; break; }
+  done <<< "$al"
+  if [[ -n "$exempt_no_hook" ]]; then
+    _pass "allowlisted agent has no hook on disk ($exempt_no_hook)"
+  else
+    _fail "an allowlisted agent has no hook on disk" "every allowlisted agent unexpectedly has a hook"
+  fi
+  run_validate "$copy"
+  assert_rc_zero "clean copy with allowlisted-but-hookless agent still passes"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 7 - Stale core-hooks.json description ("18-agent").
+# ===========================================================================
+section "[7] Stale core-hooks description: set to '18-agent' -> non-zero"
+{
+  copy="$(make_copy)"
+  jq '.description = "Core hooks for 18-agent architecture with specialized routing"' \
+    "$copy/hooks/core-hooks.json" > "$copy/hooks/core-hooks.json.tmp" \
+    && mv "$copy/hooks/core-hooks.json.tmp" "$copy/hooks/core-hooks.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails on a stale core-hooks.json description"
+  assert_out_contains "reports core-hooks.json missing N-agent" "core-hooks.json .description missing"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 8 - Roster drift in prose table: delete an agent row from CLAUDE.md.
+# ===========================================================================
+section "[8] Roster drift: delete an agent row from the CLAUDE.md table -> non-zero"
+{
+  copy="$(make_copy)"
+  # Remove the go-expert table row (shape: | **go-expert** | ... |). awk drops
+  # exactly that line, leaving everything else byte-identical.
+  awk '!/^\| \*\*go-expert\*\* \|/' "$copy/CLAUDE.md" > "$copy/CLAUDE.md.tmp" \
+    && mv "$copy/CLAUDE.md.tmp" "$copy/CLAUDE.md"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when an agent row is missing from CLAUDE.md table"
+  assert_out_contains "reports missing-row for go-expert" "missing-row: go-expert"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 9 - Generator staleness: edit inside the GENERATED region.
+# ===========================================================================
+section "[9] Generator staleness: mutate inside list-agents GENERATED region -> --check non-zero"
+{
+  copy="$(make_copy)"
+  la="$copy/commands/list-agents.md"
+  # Corrupt a data line strictly between the BEGIN/END markers so the rendered
+  # block no longer matches what's on disk. Change "total_agents": N -> 999.
+  awk '
+    /<!-- BEGIN GENERATED: list-agents-summary -->/ { inside=1; print; next }
+    /<!-- END GENERATED: list-agents-summary -->/   { inside=0; print; next }
+    inside && /"total_agents":/ { sub(/[0-9]+/, "999"); print; next }
+    { print }
+  ' "$la" > "$la.tmp" && mv "$la.tmp" "$la"
+  run_generate "$copy" --check
+  assert_rc_nonzero "generate-docs.sh --check fails on a stale generated block"
+  assert_out_contains "reports STALE for list-agents-summary" "STALE"
+  # And the full validator (check 11 wires in --check) must also fail.
+  run_validate "$copy"
+  assert_rc_nonzero "validator (check 11) also fails on the stale block"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 10 - Generator idempotency: --write on a clean copy leaves no diff.
+# ===========================================================================
+section "[10] Idempotency: generate-docs.sh --write on a clean copy is a no-op"
+{
+  copy="$(make_copy)"
+  la="$copy/commands/list-agents.md"
+  before="$(jq -nr --arg s "$(tr -d '\r' < "$la")" '$s | @base64' 2>/dev/null)"
+  # Fallback hash if jq @base64 path is awkward: compare raw bytes via cmp later.
+  cp "$la" "$copy/.la.before"
+  run_generate "$copy" --write
+  assert_rc_zero "generate-docs.sh --write succeeds on a clean copy"
+  if cmp -s "$copy/.la.before" "$la"; then
+    _pass "list-agents.md byte-identical before/after --write (idempotent)"
+  else
+    _fail "list-agents.md changed after --write" "expected no diff on a clean copy"
+  fi
+  # Belt-and-suspenders: --check must report FRESH after the no-op write.
+  run_generate "$copy" --check
+  assert_rc_zero "--check confirms blocks fresh after idempotent --write"
+  rm -rf "$copy"
+  unset before
+}
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+printf '\n%s================================================%s\n' "$C_CYN" "$C_NC"
+if [[ "$TESTS_FAIL" -eq 0 ]]; then
+  printf '%s  RESULT: PASS%s  (%s/%s assertions passed, 0 failed)\n' \
+    "$C_GRN" "$C_NC" "$TESTS_PASS" "$TESTS_RUN"
+  printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+  exit 0
+else
+  printf '%s  RESULT: FAIL%s  (%s passed, %s failed, %s total)\n' \
+    "$C_RED" "$C_NC" "$TESTS_PASS" "$TESTS_FAIL" "$TESTS_RUN"
+  printf '%s================================================%s\n' "$C_CYN" "$C_NC"
+  exit 1
+fi


### PR DESCRIPTION
Makes the framework enforce its own consistency instead of hand-maintaining it — the root cause of the agent-count / roster / category / hook-coverage drift fixed by hand across PRs #16 and #17.

## What it adds
- **`scripts/lib/facts.sh`** — single source of derived facts (roster, categories, models, hook counts, allowlist, deprecated names) from `claude.json` + the filesystem. No hardcoded counts. CR-stripping for the Windows jq build; `FRAMEWORK_ROOT` override for test isolation.
- **`scripts/validate-consistency.sh`** — 11 checks: registry↔filesystem parity, category partition, hook coverage (with `consistency.hook_coverage_allowlist` for peer-review-critic), JSON/best-effort-YAML validity, deprecated-name scan (`grep -F`, structurally excludes the canonical `.consistency` block), architecture-string match, stated-count==derived, prose-table roster presence, README focus parity, and runs the generator `--check`. Model parity is advisory (WARNING). Exits non-zero on any blocking failure.
- **`scripts/generate-docs.sh`** + `scripts/lib/{markers,render}.sh` — regenerate `<!-- BEGIN/END GENERATED -->` blocks from `claude.json` (currently the `list-agents` JSON summary); `--write`/`--check`; LF-safe, idempotent, atomic.
- **`claude.json`** — new `consistency` block + per-agent `focus`; **`hooks/core-hooks.json`** stale "18-agent" → 20 fix; existing `validate-*.sh` de-hardcoded (deleted the frozen `EXPECTED_AGENTS=18` arrays).
- **`tests/consistency.test.sh`** — portable bash harness, 10 cases, temp-copy isolated (real tree never mutated).
- **`.github/workflows/consistency.yml`** — CI gate (validator + generate `--check` + tests) on every PR; least-privilege `permissions: contents: read`.
- **`CONTRIBUTING.md`** — how to add an agent without drift.

## Verification
Validator exits 0 (0 blocking, 14 advisory model warnings); generator idempotent; harness 23/23; reviewed by code-review-gatekeeper, security-specialist, and peer-review-critic (Approve, no blockers).

## Known follow-up (deferred, non-blocking)
14 agents declare `model: opus` in `.md` frontmatter while `claude.json` assigns sonnet/haiku. Pre-existing; reported as an advisory WARNING and documented in CONTRIBUTING.md; reconciliation is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)