### PR TITLE
feat(skills): code-scoring-loop — specialist-scored quality loop for code diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The framework ships operational skills in `skills/<name>/SKILL.md` (the layout C
 | **agent-debugger** | Diagnose agent routing, loading, and configuration issues |
 | **agent-routing-advisor** | Recommend the right specialist agent for a task |
 | **code-scaffolder** | Generate idiomatic project scaffolding for supported languages |
+| **code-scoring-loop** | Rubric-based score → rewrite → rescore loop for code diffs, scored by the specialist agents before the review gates |
 | **dependency-checker** | Verify the toolchain the framework needs (git, jq, pwsh 7, node, uv) |
 | **git-workflow-assistant** | Guide branching, commit conventions, and PR workflows (incl. the peer-review gate) |
 | **hook-config-generator** | Guide for adding a new real hook (script + registration + tests) |
@@ -315,5 +316,5 @@ To add or modify agents, manage framework consistency, or understand the anti-dr
 ---
 
 <!-- BEGIN GENERATED: framework-stats -->
-**Built for Claude Code CLI • 21 Specialized Agents • 4 Hook Scripts • 8 Skills • 9 Commands • v3.1.0**
+**Built for Claude Code CLI • 21 Specialized Agents • 4 Hook Scripts • 9 Skills • 9 Commands • v3.1.0**
 <!-- END GENERATED: framework-stats -->

--- a/commands/build.md
+++ b/commands/build.md
@@ -49,6 +49,10 @@ Read the **whole spec** before writing anything: every REQ/EDGE item and its
   criteria.
 - Honour the project's quality bar (build/lint/format/tests clean) exactly as
   `commands/delegate.md` §4 defines it.
+- For a substantial diff, once the bar is green, the `code-scoring-loop`
+  skill structures a polish pass before review: a fixed rubric, the diff
+  scored by the matching specialist, weakest parts rewritten until the score
+  plateaus. Advisory — it never substitutes for the review loop in §3.
 
 ## 2. Spec coverage
 

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -88,7 +88,10 @@ in the plan**:
 For each todo, in dependency order:
 1. Write a failing test for the acceptance criteria (**red**).
 2. Delegate implementation to the right specialist until the test passes (**green**).
-3. Refactor while keeping tests green.
+3. Refactor while keeping tests green. For a substantial change, the
+   `code-scoring-loop` skill structures this step: a fixed rubric, the diff
+   scored by the matching specialist, weakest parts rewritten until the score
+   plateaus.
 4. **Update the docs this todo touches, in the same change.** If the todo adds,
    removes, or changes a public type, a DSL/config field, an event type, a CLI
    flag, a verdict, a schema, or any user-visible behavior, it has doc impact —

--- a/docs/team-presentation.md
+++ b/docs/team-presentation.md
@@ -82,7 +82,7 @@ Same task, opposite failure modes: the single session hits the ceiling and *degr
 %%{init: {"theme": "base", "themeVariables": {"background": "transparent", "lineColor": "#898781", "textColor": "#898781", "clusterBkg": "transparent", "clusterBorder": "#898781", "edgeLabelBackground": "#f0efec"}}}%%
 flowchart TD
     O["🎯 Objective"] --> R["Routing<br/>CLAUDE.md rules · /delegate · agent descriptions"]
-    R --> S["Specialist agent — 1 of 20<br/>implements, tests, commits"]
+    R --> S["Specialist agent — 1 of 21<br/>implements, tests, commits"]
     SK["📚 Skills<br/>procedural knowledge"] -.-> S
     MCP["🔌 MCP servers<br/>code intel · live docs · web"] -.-> S
     S --> C1["code-review-gatekeeper<br/>quality review"]
@@ -136,10 +136,11 @@ mindmap
     Architecture · 2
       system-architect
       product-owner
-    Quality · 3
+    Quality · 4
       comprehensive-analyst
       code-review-gatekeeper
       peer-review-critic
+      spec-compliance-reviewer
     Documentation · 1
       technical-docs-writer
 ```

--- a/docs/team-presentation.md
+++ b/docs/team-presentation.md
@@ -237,7 +237,7 @@ Loaded on demand when a task matches. An agent is *someone to delegate to*; a sk
 | agent-debugger | Diagnose routing/loading/config failures |
 | agent-routing-advisor | Pick the right agent or agent sequence |
 | code-scaffolder | Bootstrap idiomatic projects per language |
-| code-scoring-loop | Score a code diff via the specialist agents, rewrite the weakest parts, rescore until it plateaus |
+| code-scoring-loop | Score a code diff via the specialist agents, rewrite the weakest parts, rescore until it plateaus — before, never instead of, the review gates |
 | dependency-checker | Verify the toolchain (git, jq, pwsh 7, node, uv) |
 | git-workflow-assistant | Branch/commit/PR flow, incl. working *with* the Stop gate |
 | hook-config-generator | Add a new real hook (script → registration → tests) |
@@ -318,11 +318,11 @@ Prereqs: Claude Code CLI, git, PowerShell 7+, bash + jq; Node/npx and uv for the
 |---|---|
 | Specialized agents | 21 (7 categories, 3 model tiers) |
 | Hooks | 4 registered — 1 blocking gate, 3 advisory |
-| Skills | 7 loadable knowledge modules |
-| Commands | 6 management commands |
+| Skills | 9 loadable knowledge modules |
+| Commands | 9 management commands |
 | MCP servers | 5 (filesystem, context7, serena, sequential-thinking, fetch) |
 | Validator checks | 12, all derived at runtime |
-| Test assertions | 34 (consistency) + 20 (hook behavior) |
+| Test assertions | 34 (consistency) + 44 (hook behavior) |
 | CI jobs | 3, including a Windows leg |
 
 **Takeaway:** agents write the code · hooks make quality non-negotiable · the consistency system keeps the whole thing honest.

--- a/docs/team-presentation.md
+++ b/docs/team-presentation.md
@@ -228,7 +228,7 @@ Design philosophy: **one hard gate at the single choke point** (all work becomes
 
 *Field note: minutes after installation, the gate blocked its own author's session — for having unreviewed commits. It was reviewing the commits that created it.*
 
-### 3.4 Skills — procedural knowledge (8)
+### 3.4 Skills — procedural knowledge (9)
 
 Loaded on demand when a task matches. An agent is *someone to delegate to*; a skill is *knowledge the current agent absorbs*.
 
@@ -237,10 +237,12 @@ Loaded on demand when a task matches. An agent is *someone to delegate to*; a sk
 | agent-debugger | Diagnose routing/loading/config failures |
 | agent-routing-advisor | Pick the right agent or agent sequence |
 | code-scaffolder | Bootstrap idiomatic projects per language |
+| code-scoring-loop | Score a code diff via the specialist agents, rewrite the weakest parts, rescore until it plateaus |
 | dependency-checker | Verify the toolchain (git, jq, pwsh 7, node, uv) |
 | git-workflow-assistant | Branch/commit/PR flow, incl. working *with* the Stop gate |
 | hook-config-generator | Add a new real hook (script → registration → tests) |
 | refactoring-advisor | Spot code smells, prioritize refactorings |
+| self-scoring-loop | Rubric-score a non-code deliverable, rewrite the weakest parts, rescore until it plateaus |
 
 ### 3.5 MCP servers — senses and instruments (5)
 

--- a/docs/team-presentation.md
+++ b/docs/team-presentation.md
@@ -108,7 +108,7 @@ flowchart TD
 
 ## 3. Components
 
-### 3.1 Agents — the workforce (20)
+### 3.1 Agents — the workforce (21)
 
 An agent = a markdown file: YAML frontmatter (name, routing description, model tier, tools) + a system prompt. **Routing is description-driven** — the task text is matched against agent descriptions, so a well-written description *is* the router.
 

--- a/skills/code-scoring-loop/SKILL.md
+++ b/skills/code-scoring-loop/SKILL.md
@@ -32,11 +32,14 @@ things change when the deliverable is a diff:
 
 ## Gate zero — the quality bar
 
-Before iteration 1, the project quality bar must be clean exactly as
-`commands/delegate.md` §4 defines it: build 0 errors / 0 warnings, linter
-clean, formatter no diffs, full unit-test suite green. Correctness is binary
-and comes first; scoring a red build is meaningless. If the bar fails, fix
-that — this loop is not for broken code.
+Before iteration 1, the mechanical checks of `commands/delegate.md` §4's
+quality bar must be clean: build 0 errors / 0 warnings, linter clean,
+formatter no diffs, full unit-test suite green. (§4's docs bullet is not part
+of gate zero — in the `/delegate` flow it lands in the per-todo doc step that
+follows the refactor.) Inside `/delegate`'s BDD loop this means running the
+full suite at the start of the refactor step rather than waiting for §3
+step 5. Correctness is binary and comes first; scoring a red build is
+meaningless. If the bar fails, fix that — this loop is not for broken code.
 
 ## The Loop
 
@@ -54,12 +57,15 @@ that — this loop is not for broken code.
    not criteria. The rubric is fixed for the rest of the loop.
 3. **Delegate scoring to the matching specialist.** Route by the diff's
    domain per the framework routing table (`rust-expert` for a Rust diff,
-   `typescript-expert` for TypeScript, …); use `code-review-gatekeeper` when
-   the change spans languages or no language expert fits. Launch a **fresh**
+   `typescript-expert` for TypeScript, …); use `comprehensive-analyst` when
+   the change spans languages or no language expert fits — not
+   `code-review-gatekeeper`, which must stay outside the polish loop so the
+   gate's judgment remains independent of the rubric. Launch a **fresh**
    subagent instance each round and hand it the diff, the rubric, and the
    instruction to return a 0–100 score with a one-line justification per
    criterion. Score honestly — an inflated score ends the loop early and
-   defeats it.
+   defeats it. If the **first** score is **≥ 90**, say so and stop — the loop
+   is for improvement, not ceremony.
 4. **Name the 1–2 weakest criteria** from the scorer's report and exactly why
    they lost points.
 5. **Rewrite only the weak parts** (delegating to the implementing specialist
@@ -69,8 +75,6 @@ that — this loop is not for broken code.
 6. **Rescore and decide** — same rubric, fresh scorer instance:
    - Improvement **< 3 points**, or **3 iterations** reached → stop. More
      loops past a plateau produce churn, not quality.
-   - Score **≥ 90 on the first pass** → say so and stop; the loop is for
-     improvement, not ceremony.
    - Otherwise → back to step 4.
 7. **Report** the rubric, the final score with per-criterion breakdown, and
    the score trajectory (e.g. 68 → 81 → 86) — then proceed to the framework's

--- a/skills/code-scoring-loop/SKILL.md
+++ b/skills/code-scoring-loop/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: code-scoring-loop
+description: Iteratively improve a code change by having the matching specialist agent score the diff 0-100 against an explicit rubric, rewriting the weakest parts, and repeating until the score plateaus. Use after the quality bar is green (build/lint/format/tests clean) but before the review gates — e.g. polishing an implementation or refactor, or when asked to "clean up" code without concrete criteria. Code-side sibling of self-scoring-loop.
+---
+
+# Code-Scoring Loop
+
+The same converging loop as `self-scoring-loop` — rubric first, score, rewrite
+the weakest parts, rescore until improvement stalls — adapted for code. Three
+things change when the deliverable is a diff:
+
+1. **Objective checks come first.** The toolchain already judges correctness;
+   the rubric only covers what build/lint/tests *cannot* check.
+2. **The author never grades their own work.** Scoring is delegated to the
+   framework's specialist agents, so the score is an independent read, not a
+   self-assessment.
+3. **The loop feeds the gates, it does not replace them.** A polished diff
+   still goes through `code-review-gatekeeper` and `peer-review-critic`
+   unchanged — this loop just means it arrives pre-polished.
+
+## When to Apply
+
+- An implementation or refactor is green but has not been judged on the
+  dimensions tests can't check (readability, error-handling completeness,
+  test quality, idiomatic fit).
+- Before handing a substantial diff to `code-review-gatekeeper` — fewer gate
+  iterations when the obvious weaknesses are already fixed.
+- The user asks to "polish", "clean up", or "tighten" code without concrete
+  criteria.
+- After the refactor step of a `/delegate` todo, when the change is large
+  enough that a structured polish pass beats ad-hoc tidying.
+
+## Gate zero — the quality bar
+
+Before iteration 1, the project quality bar must be clean exactly as
+`commands/delegate.md` §4 defines it: build 0 errors / 0 warnings, linter
+clean, formatter no diffs, full unit-test suite green. Correctness is binary
+and comes first; scoring a red build is meaningless. If the bar fails, fix
+that — this loop is not for broken code.
+
+## The Loop
+
+1. **Scope the diff.** The unit being scored is the *change* (branch vs base,
+   or the todo's touched files) — not the whole repository. Pre-existing debt
+   outside the diff is out of scope.
+2. **Write the rubric first — before judging.** 5–7 criteria specific to this
+   change, each with a weight (weights sum to 100), drawn from what tooling
+   cannot verify: naming and readability, error-handling completeness at
+   boundaries, test quality (assertion strength and edge coverage — not just
+   line coverage), consistency with the codebase's existing idioms, API and
+   interface design, duplication and complexity, security hygiene of touched
+   surfaces. Never spend rubric weight on what gate zero already enforces
+   (compiles, lint-clean, formatted, tests pass) — those are preconditions,
+   not criteria. The rubric is fixed for the rest of the loop.
+3. **Delegate scoring to the matching specialist.** Route by the diff's
+   domain per the framework routing table (`rust-expert` for a Rust diff,
+   `typescript-expert` for TypeScript, …); use `code-review-gatekeeper` when
+   the change spans languages or no language expert fits. Launch a **fresh**
+   subagent instance each round and hand it the diff, the rubric, and the
+   instruction to return a 0–100 score with a one-line justification per
+   criterion. Score honestly — an inflated score ends the loop early and
+   defeats it.
+4. **Name the 1–2 weakest criteria** from the scorer's report and exactly why
+   they lost points.
+5. **Rewrite only the weak parts** (delegating to the implementing specialist
+   where routing says so). Keep what scored well. Rewrites are
+   **behavior-preserving**: re-run the quality bar after every rewrite; a
+   rewrite that breaks a test is reverted, not argued for.
+6. **Rescore and decide** — same rubric, fresh scorer instance:
+   - Improvement **< 3 points**, or **3 iterations** reached → stop. More
+     loops past a plateau produce churn, not quality.
+   - Score **≥ 90 on the first pass** → say so and stop; the loop is for
+     improvement, not ceremony.
+   - Otherwise → back to step 4.
+7. **Report** the rubric, the final score with per-criterion breakdown, and
+   the score trajectory (e.g. 68 → 81 → 86) — then proceed to the framework's
+   normal review gates.
+
+## Rules
+
+- The bar before the rubric — never score a build that isn't green.
+- Scorer ≠ author, always: every score comes from a delegated fresh
+  specialist run, never from the agent that wrote the code.
+- Rubric before judgment, visible in the report, never revised mid-loop.
+- Behavior-preserving only: never trade a passing test for a rubric point.
+  Spec conformance is a gate (`spec-compliance-reviewer`), not a rubric
+  criterion — requirement changes do not belong in a polish loop.
+- Advisory, and strictly *before* the gates: `code-review-gatekeeper`,
+  `peer-review-critic`, and the peer-review Stop gate apply unchanged. A 95
+  here skips nothing.

--- a/skills/code-scoring-loop/SKILL.md
+++ b/skills/code-scoring-loop/SKILL.md
@@ -27,8 +27,9 @@ things change when the deliverable is a diff:
   iterations when the obvious weaknesses are already fixed.
 - The user asks to "polish", "clean up", or "tighten" code without concrete
   criteria.
-- After the refactor step of a `/delegate` todo, when the change is large
-  enough that a structured polish pass beats ad-hoc tidying.
+- After the refactor step of a `/delegate` todo, or once a `/build` iteration
+  is green before its spec-compliance review, when the change is large enough
+  that a structured polish pass beats ad-hoc tidying.
 
 ## Gate zero — the quality bar
 

--- a/skills/code-scoring-loop/SKILL.md
+++ b/skills/code-scoring-loop/SKILL.md
@@ -27,9 +27,10 @@ things change when the deliverable is a diff:
   iterations when the obvious weaknesses are already fixed.
 - The user asks to "polish", "clean up", or "tighten" code without concrete
   criteria.
-- After the refactor step of a `/delegate` todo, or once a `/build` iteration
-  is green before its spec-compliance review, when the change is large enough
-  that a structured polish pass beats ad-hoc tidying.
+- After the refactor step of a `/delegate` todo, or the first time a `/build`
+  run goes green before its spec-compliance review (once per run — fix
+  iterations of the review loop don't re-enter the polish pass), when the
+  change is large enough that a structured polish pass beats ad-hoc tidying.
 
 ## Gate zero — the quality bar
 

--- a/skills/self-scoring-loop/SKILL.md
+++ b/skills/self-scoring-loop/SKILL.md
@@ -7,7 +7,7 @@ description: Iteratively improve a non-code deliverable (spec, plan, document, d
 
 Turn a single-shot draft into a converging loop: score the work against an explicit rubric, fix the weakest parts, and repeat until improvement stalls. Scoring and rewriting are different acts — critiquing the work *before* rewriting turns blind editing into directed search.
 
-This is the quality loop for deliverables that have no test suite. Code goes through the review gates (`code-review-gatekeeper`, `peer-review-critic`); everything else can go through this.
+This is the quality loop for deliverables that have no test suite. For code, use the `code-scoring-loop` sibling skill — the same loop with the diff scored by the framework's specialist agents, run before (never instead of) the review gates (`code-review-gatekeeper`, `peer-review-critic`).
 
 ## When to Apply
 
@@ -33,4 +33,4 @@ This is the quality loop for deliverables that have no test suite. Code goes thr
 - The rubric must be *visible* in the report; a hidden rubric is unfalsifiable.
 - Never revise the rubric mid-loop to make a score look better.
 - If the deliverable scores ≥ 90 on the first pass, say so and stop — the loop is for improvement, not ceremony.
-- This loop is single-agent and advisory; it does not replace the framework's review gates for code.
+- This loop is single-agent and advisory; it does not replace the framework's review gates for code — code takes the `code-scoring-loop` variant.


### PR DESCRIPTION
## Summary

Merges the code-scoring-loop work from a parallel Claude session:

- New skill `skills/code-scoring-loop/SKILL.md` — a specialist-scored quality loop for code diffs (peer-review findings already addressed on the branch).
- `/build` gains an advisory code-scoring-loop polish pass (once per /build run); `/delegate` and `self-scoring-loop` cross-references updated.
- README + team-presentation agent-count sweep (21 agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)