### PR TITLE
docs: show the /build code-scoring polish pass on the pipeline poster

### DIFF
--- a/docs/pipeline-infographic.svg
+++ b/docs/pipeline-infographic.svg
@@ -72,6 +72,7 @@
   <text x="840" y="178" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#fff">2. BUILD</text>
   <text x="840" y="196" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#e8e8e8">• Resolve approved spec</text>
   <text x="840" y="210" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#e8e8e8">• Build via specialists</text>
+  <text x="840" y="224" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#d0f0f0">• Code-scoring polish pass (advisory)</text>
 
   <!-- Arrow BUILD to REVIEW & FIX LOOP -->
   <line x1="960" y1="200" x2="1020" y2="200" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
@@ -296,5 +297,5 @@
   <text x="50" y="905" font-family="Arial, sans-serif" font-size="11" fill="#666">💬 Interview: clarify requirements  •  📋 Delegate: create / refine spec  •  ◇ Decision Gate: quality checkpoint  •  📦 Build: implement via specialists  •  🛡️ Spec Coverage: map every requirement  •  🔄 Review Loop: improve until approved</text>
 
   <!-- SOURCES (y935-955) -->
-  <text x="50" y="950" font-family="Consolas, monospace" font-size="9" fill="#999">Sources: commands/spec.md · commands/build.md · commands/delegate.md · skills/self-scoring-loop/SKILL.md · hooks/stop-peer-review-gate.ps1 · hooks/record-subagent-run.ps1 — Generated: 2026-07-21</text>
+  <text x="50" y="950" font-family="Consolas, monospace" font-size="9" fill="#999">Sources: commands/spec.md · commands/build.md · commands/delegate.md · skills/self-scoring-loop/SKILL.md · skills/code-scoring-loop/SKILL.md · hooks/stop-peer-review-gate.ps1 · hooks/record-subagent-run.ps1 — Generated: 2026-07-21</text>
 </svg>


### PR DESCRIPTION
## Summary

PR #24 added the advisory code-scoring-loop polish pass to /build; the pipeline poster (docs/pipeline-infographic.svg) now depicts it — a third bullet in the "2. BUILD" box ("Code-scoring polish pass (advisory)") — and the drift-detection footer cites skills/code-scoring-loop/SKILL.md alongside the existing sources. Layout render-verified at 1440x960; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)