### PR TITLE
chore: post-merge hardening follow-ups

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -95,6 +95,24 @@ jobs:
           $results | Format-Table -AutoSize
           if ($results | Where-Object Severity -eq 'Error') { exit 1 }
 
+  hooks-macos:
+    name: hook behavior + validators (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure jq is available
+        run: |
+          command -v jq >/dev/null || { echo "jq missing"; exit 1; }
+          jq --version
+
+      - name: Validate consistency (macOS/POSIX)
+        run: bash scripts/validate-consistency.sh
+
+      - name: Run hooks test harness (macOS/POSIX)
+        run: bash tests/hooks.test.sh
+
   hooks-windows:
     name: hook behavior + validators (windows)
     runs-on: windows-latest

--- a/mcp-plugin/commands/setup.md
+++ b/mcp-plugin/commands/setup.md
@@ -92,9 +92,9 @@ try {
 
 ```bash
 # EXAMPLE: Copy and paste this into YOUR OWN terminal:
-# EXAMPLE: Secure token capture and persistence
-read -r -s -p "Paste your Context7 API key: " C7KEY
-# (the -p prompt flag is bash-specific — run this snippet under bash; zsh users: `printf 'Paste your Context7 API key: '; read -r -s C7KEY`)
+# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and other POSIX shells)
+printf 'Paste your Context7 API key: '
+read -r -s C7KEY
 echo
 if ! echo "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+ without spaces or special chars" >&2
@@ -195,9 +195,9 @@ Detect the user's login shell and append to its profile (with guard to prevent d
 
 ```bash
 # EXAMPLE: Option C - Validate and persist token (user provides in chat)
-# EXAMPLE: Secure token capture and persistence
-read -r -s -p "Paste your Context7 API key: " C7KEY
-# (the -p prompt flag is bash-specific — run this snippet under bash; zsh users: `printf 'Paste your Context7 API key: '; read -r -s C7KEY`)
+# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and other POSIX shells)
+printf 'Paste your Context7 API key: '
+read -r -s C7KEY
 echo
 if ! echo "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+$ without spaces or special chars." >&2
@@ -220,6 +220,21 @@ else
   esac
 fi
 unset C7KEY
+```
+
+**On macOS/Linux (fish):** — EXAMPLE code
+
+```fish
+# EXAMPLE: Option C - Validate and persist token (fish shell)
+# EXAMPLE: Secure token capture and persistence
+set -l c7key (read -s -P 'Paste your Context7 API key: ')
+if echo "$c7key" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null 2>&1
+  grep -q "^set -Ux CONTEXT7_API_KEY" ~/.config/fish/config.fish 2>/dev/null || set -Ux CONTEXT7_API_KEY "$c7key"  # EXAMPLE: setup
+  echo "Added to fish configuration"
+else
+  echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+ without spaces or special chars" >&2
+end
+set -e c7key
 ```
 
 4. **SECURITY RULE:** After persisting, immediately proceed to Step 5. Never echo the token back in full — mask it to 4 leading characters only when confirming.

--- a/mcp-plugin/commands/setup.md
+++ b/mcp-plugin/commands/setup.md
@@ -92,11 +92,11 @@ try {
 
 ```bash
 # EXAMPLE: Copy and paste this into YOUR OWN terminal:
-# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and other POSIX shells)
+# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and ksh; read -s is a shell extension, not POSIX — dash/ash don't support it)
 printf 'Paste your Context7 API key: '
 read -r -s C7KEY
-echo
-if ! echo "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
+printf '\n'
+if ! printf '%s\n' "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+ without spaces or special chars" >&2
 else
   SHELL_NAME=$(basename "$SHELL")
@@ -126,8 +126,8 @@ unset C7KEY
 # EXAMPLE: Copy and paste this into YOUR OWN fish terminal:
 # EXAMPLE: Secure token capture and persistence
 set -l c7key (read -s -P 'Paste your Context7 API key: ')
-if echo "$c7key" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null 2>&1
-  grep -q "^set -Ux CONTEXT7_API_KEY" ~/.config/fish/config.fish 2>/dev/null || set -Ux CONTEXT7_API_KEY "$c7key"  # EXAMPLE: setup
+if printf '%s\n' "$c7key" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null 2>&1
+  if not set -q CONTEXT7_API_KEY; set -Ux CONTEXT7_API_KEY "$c7key"; end  # EXAMPLE: setup
   echo "Added to fish configuration"
 else
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+ without spaces or special chars" >&2
@@ -195,11 +195,11 @@ Detect the user's login shell and append to its profile (with guard to prevent d
 
 ```bash
 # EXAMPLE: Option C - Validate and persist token (user provides in chat)
-# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and other POSIX shells)
+# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and ksh; read -s is a shell extension, not POSIX — dash/ash don't support it)
 printf 'Paste your Context7 API key: '
 read -r -s C7KEY
-echo
-if ! echo "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
+printf '\n'
+if ! printf '%s\n' "$C7KEY" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null; then
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+$ without spaces or special chars." >&2
 else
   SHELL_NAME=$(basename "$SHELL")
@@ -228,8 +228,8 @@ unset C7KEY
 # EXAMPLE: Option C - Validate and persist token (fish shell)
 # EXAMPLE: Secure token capture and persistence
 set -l c7key (read -s -P 'Paste your Context7 API key: ')
-if echo "$c7key" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null 2>&1
-  grep -q "^set -Ux CONTEXT7_API_KEY" ~/.config/fish/config.fish 2>/dev/null || set -Ux CONTEXT7_API_KEY "$c7key"  # EXAMPLE: setup
+if printf '%s\n' "$c7key" | grep -E '^[A-Za-z0-9_-]+$' > /dev/null 2>&1
+  if not set -q CONTEXT7_API_KEY; set -Ux CONTEXT7_API_KEY "$c7key"; end  # EXAMPLE: setup
   echo "Added to fish configuration"
 else
   echo "ERROR: API key contains invalid characters. Must match ^[A-Za-z0-9_-]+ without spaces or special chars" >&2

--- a/scripts/lib/facts.sh
+++ b/scripts/lib/facts.sh
@@ -200,7 +200,10 @@ fact_registered_sh_scripts() {
   _facts_require_jq || return $?
   _facts_require_hooks_json || return $?
   # Extract hook names from dispatch.sh arguments (the word after dispatch.sh in the chain)
-  # and convert to .sh basenames, then add dispatch.sh itself
+  # and convert to .sh basenames, then add dispatch.sh itself.
+  # NOTE: The regex REQUIRES hook names to follow dispatch.sh separated by a space or quote
+  # (scan pattern: 'dispatch[.]sh[" ] +([a-zA-Z0-9._-]+)'). Unquoted names without space
+  # will silently extract nothing; the orphan-sh-script check catches these loudly later.
   {
     _facts_jq -r '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command // empty] | .[] | scan("dispatch[.]sh[\" ] +([a-zA-Z0-9._-]+)") | .[0] + ".sh"' \
         "$FACTS_HOOKS_JSON"

--- a/scripts/lib/hookcheck.sh
+++ b/scripts/lib/hookcheck.sh
@@ -29,9 +29,6 @@ SessionStart
 SessionEnd
 PreCompact'
 
-# Problem types (continued from header):
-#   chain-name-mismatch    dispatch-arg name differs from .ps1 filename stem in same chain
-
 # hookcheck_problems - print one "<type>TAB<subject>" line per problem found.
 # Empty output (and exit 0) means the hook architecture is consistent.
 # Parity checks assert filename presence/parity only; they do not inspect command strings for appended shell content (dev/CI lint, not a runtime boundary).
@@ -47,8 +44,12 @@ PreCompact'
 #   missing-dispatch-sh    dispatch.sh not found or not referenced in all chains
 #   missing-sh-shebang     hook .sh script lacks #!/bin/sh header
 #   missing-set-u          hook .sh script lacks 'set -u' line
+#   missing-dispatch-allowlist  hook name missing from dispatch.sh allowlist
+#   chain-name-mismatch    dispatch-arg name differs from .ps1 filename stem in same chain
 hookcheck_problems() {
   local registered_ps1 registered_sh sh_files ps1_files events e f first
+  local dispatch_line dispatch_pattern allowlist_names hook_name hook_base
+  local dispatch_arg ps1_file ps1_path ps1_stem cmd
 
   _facts_require_hooks_json || {
     printf 'no-hooks-block\thooks/hooks.json\n'
@@ -176,12 +177,13 @@ hookcheck_problems() {
 
   # (k) chain command strings: dispatch.sh argument must match .ps1 filename stem
   # Each chain has format: sh "...dispatch.sh" <name> || pwsh -File ".../name.ps1"
-  _facts_jq -r '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command // empty]' "$FACTS_HOOKS_JSON" | while IFS= read -r cmd; do
+  _facts_jq -r '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command // empty] | .[]' "$FACTS_HOOKS_JSON" | while IFS= read -r cmd; do
     [[ -z "$cmd" || ! "$cmd" =~ dispatch\.sh ]] && continue
-    # Extract dispatch-arg: the word after dispatch.sh (may be quoted)
-    dispatch_arg=$(printf '%s' "$cmd" | sed -n 's/.*dispatch\.sh[[:space:]]*["'"'"']\?[[:space:]]*\([^"'"'"' ][^ ]*\).*/\1/p')
-    # Extract .ps1 filename: the basename after .ps1 argument
-    ps1_file=$(printf '%s' "$cmd" | sed -n 's/.*\.ps1[[:space:]]*"\?\([^"]*\.ps1\).*/\1/p' | xargs basename 2>/dev/null)
+    # Extract dispatch-arg: the word after dispatch.sh (may be quoted or bare)
+    dispatch_arg=$(printf '%s' "$cmd" | sed -n 's/.*dispatch\.sh[[:space:]]*["'"'"']\{0,1\}[[:space:]]*\([^"'"'"' ][^ ]*\).*/\1/p')
+    # Extract .ps1 filename: the basename after -File argument (look for -File context, not greedy from start)
+    ps1_path=$(printf '%s' "$cmd" | sed -n 's/.*-File[[:space:]]*"\([^"]*\.ps1\)".*/\1/p')
+    ps1_file=$(basename "$ps1_path" 2>/dev/null)
     ps1_stem="${ps1_file%.ps1}"
 
     if [[ -n "$dispatch_arg" && -n "$ps1_stem" && "$dispatch_arg" != "$ps1_stem" ]]; then

--- a/scripts/lib/hookcheck.sh
+++ b/scripts/lib/hookcheck.sh
@@ -29,6 +29,9 @@ SessionStart
 SessionEnd
 PreCompact'
 
+# Problem types (continued from header):
+#   chain-name-mismatch    dispatch-arg name differs from .ps1 filename stem in same chain
+
 # hookcheck_problems - print one "<type>TAB<subject>" line per problem found.
 # Empty output (and exit 0) means the hook architecture is consistent.
 # Parity checks assert filename presence/parity only; they do not inspect command strings for appended shell content (dev/CI lint, not a runtime boundary).
@@ -151,7 +154,7 @@ hookcheck_problems() {
     # Look for lines like: "  hook1|hook2|hook3) ;;" between "case "$hook" in" and "esac"
     # Extract the first pattern line (before the *) catch-all), then extract just the pattern part
     dispatch_line=$(sed -n '/^[[:space:]]*case "\$hook" in$/,/^[[:space:]]*esac$/p' "$FACTS_HOOKS_DIR/dispatch.sh" 2>/dev/null | \
-                    grep -v '^\*' | grep -v '^[[:space:]]*case' | grep -v '^[[:space:]]*esac' | head -1)
+                    grep -v '^[[:space:]]*\*' | grep -v '^[[:space:]]*case' | grep -v '^[[:space:]]*esac' | head -1)
     # Extract pattern: everything before the closing paren
     dispatch_pattern=$(printf '%s' "$dispatch_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*)[[:space:]]*;;.*//')
 
@@ -170,4 +173,19 @@ hookcheck_problems() {
       fi
     done <<< "$registered_sh"
   fi
+
+  # (k) chain command strings: dispatch.sh argument must match .ps1 filename stem
+  # Each chain has format: sh "...dispatch.sh" <name> || pwsh -File ".../name.ps1"
+  _facts_jq -r '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command // empty]' "$FACTS_HOOKS_JSON" | while IFS= read -r cmd; do
+    [[ -z "$cmd" || ! "$cmd" =~ dispatch\.sh ]] && continue
+    # Extract dispatch-arg: the word after dispatch.sh (may be quoted)
+    dispatch_arg=$(printf '%s' "$cmd" | sed -n 's/.*dispatch\.sh[[:space:]]*["'"'"']\?[[:space:]]*\([^"'"'"' ][^ ]*\).*/\1/p')
+    # Extract .ps1 filename: the basename after .ps1 argument
+    ps1_file=$(printf '%s' "$cmd" | sed -n 's/.*\.ps1[[:space:]]*"\?\([^"]*\.ps1\).*/\1/p' | xargs basename 2>/dev/null)
+    ps1_stem="${ps1_file%.ps1}"
+
+    if [[ -n "$dispatch_arg" && -n "$ps1_stem" && "$dispatch_arg" != "$ps1_stem" ]]; then
+      printf 'chain-name-mismatch\t%s (dispatch: %s vs .ps1: %s)\n' "$cmd" "$dispatch_arg" "$ps1_stem"
+    fi
+  done
 }

--- a/scripts/migrate-legacy.ps1
+++ b/scripts/migrate-legacy.ps1
@@ -645,7 +645,10 @@ if ((Test-Path $gitDir) -and (Test-Path $claudeJsonInHome)) {
                 Write-Host "    ... and $($filesToDelete.Count - 20) more"
             }
         }
-        $summary['checkout'] = "$fileCount tracked file(s), .git"
+        # Only update summary if checkout didn't abort (preserve abort message)
+        if ($checkoutCanProceed) {
+            $summary['checkout'] = "$fileCount tracked file(s), .git"
+        }
     }
 } else {
     Write-Host '  ~/.claude is not a git clone - nothing to do'

--- a/scripts/migrate-legacy.ps1
+++ b/scripts/migrate-legacy.ps1
@@ -644,10 +644,10 @@ if ((Test-Path $gitDir) -and (Test-Path $claudeJsonInHome)) {
             if ($filesToDelete.Count -gt 20) {
                 Write-Host "    ... and $($filesToDelete.Count - 20) more"
             }
-            # Only update summary if checkout didn't abort (preserve abort message)
-            if ($checkoutCanProceed) {
-                $summary['checkout'] = "$fileCount tracked file(s), .git"
-            }
+        }
+        # Only update summary if checkout didn't abort (preserve abort message)
+        if ($checkoutCanProceed) {
+            $summary['checkout'] = "$fileCount tracked file(s), .git"
         }
         # If Apply but not checkoutCanProceed: abort message already printed, don't print anything else
     }

--- a/scripts/migrate-legacy.ps1
+++ b/scripts/migrate-legacy.ps1
@@ -634,7 +634,7 @@ if ((Test-Path $gitDir) -and (Test-Path $claudeJsonInHome)) {
             }
 
             Write-Host "  deleted $($filesToDelete.Count) tracked file(s) and .git directory"
-        } else {
+        } elseif (-not $Apply) {
             # Dry-run: show first 20 files
             $display = $filesToDelete | Select-Object -First 20
             Write-Host "  (dry-run: would delete $($filesToDelete.Count) tracked file(s)):"
@@ -644,11 +644,12 @@ if ((Test-Path $gitDir) -and (Test-Path $claudeJsonInHome)) {
             if ($filesToDelete.Count -gt 20) {
                 Write-Host "    ... and $($filesToDelete.Count - 20) more"
             }
+            # Only update summary if checkout didn't abort (preserve abort message)
+            if ($checkoutCanProceed) {
+                $summary['checkout'] = "$fileCount tracked file(s), .git"
+            }
         }
-        # Only update summary if checkout didn't abort (preserve abort message)
-        if ($checkoutCanProceed) {
-            $summary['checkout'] = "$fileCount tracked file(s), .git"
-        }
+        # If Apply but not checkoutCanProceed: abort message already printed, don't print anything else
     }
 } else {
     Write-Host '  ~/.claude is not a git clone - nothing to do'

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -199,6 +199,8 @@ section "[3] Hook registration parity (hooks/hooks.json <-> hooks/*.ps1)"
                               detail "missing-set-u: $subject" ;;
         missing-dispatch-allowlist) fail "dispatch.sh allowlist missing hook name: hooks/$subject"
                               detail "missing-dispatch-allowlist: $subject" ;;
+        chain-name-mismatch)  fail "hook chain command mismatch: dispatch arg differs from .ps1 filename: $subject"
+                              detail "chain-name-mismatch: $subject" ;;
         invalid-hook-event)   fail "unknown Claude Code hook event in hooks/hooks.json: $subject"
                               detail "invalid-hook-event: $subject" ;;
         missing-requires-ps7) fail ".ps1 hook script lacks '#Requires -Version 7.0' header: hooks/$subject"

--- a/scripts/validate-hooks.sh
+++ b/scripts/validate-hooks.sh
@@ -3,10 +3,13 @@
 #
 # Thin wrapper over the shared hook checks in scripts/lib/hookcheck.sh (the same
 # logic validate-consistency.sh runs as check 3, so the two cannot drift):
-#   - every hook script registered in hooks/hooks.json exists in hooks/
-#   - every hooks/*.ps1 is registered (no dead scripts)
+#   - every hook script registered in hooks/hooks.json exists (both .ps1 and .sh)
+#   - every hooks/*.ps1 and hooks/*.sh is registered (no orphaned scripts)
+#   - dispatch.sh exists and is referenced in all hook chains
+#   - every hook chain's dispatch argument matches its .ps1 filename stem
 #   - every registered event is a real Claude Code hook event
-#   - every hook script pins PowerShell 7 ('#Requires -Version 7.0')
+#   - every .ps1 hook script pins PowerShell 7 ('#Requires -Version 7.0')
+#   - every .sh hook script has #!/bin/sh shebang and 'set -u' line
 # Plus a local deprecated-name scan over the hook scripts.
 
 set -uo pipefail
@@ -38,9 +41,10 @@ if [[ -n "$PROBLEMS" ]]; then
     ERRORS=$((ERRORS + 1))
   done <<< "$PROBLEMS"
 else
-  n_scripts="$(fact_hook_script_files | grep -c . || true)"
+  n_ps1_scripts="$(fact_hook_script_files | grep -c . || true)"
+  n_sh_scripts="$(fact_hook_sh_impl_files | grep -c . || true)"
   n_events="$(fact_hook_events | grep -c . || true)"
-  echo "OK: $n_scripts hook script(s) registered across $n_events event(s); no orphans; all events valid; all pin PS7"
+  echo "OK: $n_ps1_scripts .ps1 + $n_sh_scripts .sh hook script(s) registered across $n_events event(s); dispatch chains coherent; all events valid"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/consistency.test.sh
+++ b/tests/consistency.test.sh
@@ -266,6 +266,25 @@ section "[6b] dispatch.sh allowlist incomplete: drop 'record-subagent-run' from 
 }
 
 # ===========================================================================
+# CASE 6c - chain command mismatch: dispatch arg differs from .ps1 filename
+#           -> check 3 must fail.
+# ===========================================================================
+section "[6c] chain command mismatch: dispatch arg != .ps1 filename -> non-zero (check 3)"
+{
+  copy="$(make_copy)"
+  # Mutate one chain: change the dispatch arg but leave the .ps1 filename unchanged
+  # Original: sh "...dispatch.sh" record-subagent-run || pwsh -File ".../record-subagent-run.ps1"
+  # Mutated:  sh "...dispatch.sh" record-subagent-runs || pwsh -File ".../record-subagent-run.ps1" (typo in dispatch arg)
+  jq '.hooks.PostToolUse[0].hooks[0].command = "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/dispatch.sh\" record-subagent-runs || pwsh -NoProfile -File \"${CLAUDE_PLUGIN_ROOT}/hooks/record-subagent-run.ps1\""' \
+    "$copy/hooks/hooks.json" > "$copy/hooks/hooks.json.tmp" \
+    && mv "$copy/hooks/hooks.json.tmp" "$copy/hooks/hooks.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails on chain command mismatch"
+  assert_out_contains "reports chain-name-mismatch" "chain-name-mismatch"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
 # CASE 7 - Stale claude.json description ("18-agent") -> check 6a must fail.
 # ===========================================================================
 section "[7] Stale architecture description: claude.json set to '18-agent' -> non-zero"

--- a/tests/hooks-equivalence.test.sh
+++ b/tests/hooks-equivalence.test.sh
@@ -150,7 +150,7 @@ printf '%s================================================%s\n' "$C_CYN" "$C_NC"
 # --- RECORDER-A: SubagentStop APPROVED
 section "[RECORDER-A] SubagentStop APPROVED plain-string"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
   state_ps_win=$(cygpath -w "$state_ps_msys" 2>/dev/null || echo "$state_ps_msys")
@@ -168,7 +168,7 @@ section "[RECORDER-A] SubagentStop APPROVED plain-string"
 # --- RECORDER-B: PostToolUse CHANGES_REQUIRED
 section "[RECORDER-B] PostToolUse CHANGES_REQUIRED content-array"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
   state_ps_win=$(cygpath -w "$state_ps_msys" 2>/dev/null || echo "$state_ps_msys")
@@ -186,7 +186,7 @@ section "[RECORDER-B] PostToolUse CHANGES_REQUIRED content-array"
 # --- RECORDER-C: Verdict-less
 section "[RECORDER-C] Verdict-less run (ran-marker)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
   state_ps_win=$(cygpath -w "$state_ps_msys" 2>/dev/null || echo "$state_ps_msys")
@@ -219,7 +219,7 @@ section "[RECORDER-C] Verdict-less run (ran-marker)"
 # --- RECORDER-D: Scoped
 section "[RECORDER-D] Scoped agentic-framework:peer-review-critic"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
   state_ps_win=$(cygpath -w "$state_ps_msys" 2>/dev/null || echo "$state_ps_msys")
@@ -237,7 +237,7 @@ section "[RECORDER-D] Scoped agentic-framework:peer-review-critic"
 # --- RECORDER-E: Stale-guard
 section "[RECORDER-E] Stale-guard: instance-dedupe suppression"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
   state_ps_win=$(cygpath -w "$state_ps_msys" 2>/dev/null || echo "$state_ps_msys")
@@ -271,7 +271,7 @@ section "[RECORDER-E] Stale-guard: instance-dedupe suppression"
 # --- GATE-A: APPROVED allows
 section "[GATE-A] APPROVED marker allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
@@ -315,7 +315,7 @@ section "[GATE-A] APPROVED marker allows"
 # --- GATE-B: CHANGES_REQUIRED blocks
 section "[GATE-B] CHANGES_REQUIRED marker blocks"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"
@@ -374,7 +374,7 @@ section "[GATE-B] CHANGES_REQUIRED marker blocks"
 # --- GATE-C: No marker blocks
 section "[GATE-C] No marker blocks"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   state_ps_msys="$workdir/state_ps"
   state_sh_msys="$workdir/state_sh"

--- a/tests/hooks-equivalence.test.sh
+++ b/tests/hooks-equivalence.test.sh
@@ -36,8 +36,16 @@ TESTS_FAIL=0
 # Create a single mktemp-based harness root for all test fixtures.
 # All temp dirs are created under this single root; cleanup_all removes
 # it wholesale. This eliminates PID-based naming collision issues and
-# ensures predictable cleanup across concurrent runs.
+# ensures predictable cleanup across concurrent runs (a prior incident:
+# a shared/global glob pattern caused one test-harness instance to delete
+# another CONCURRENT instance's live fixture directories mid-run).
 HARNESS_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/hooks-equiv-test.XXXXXXXX") || exit 1
+
+cleanup_all() {
+  cd / 2>/dev/null || true
+  [ -n "${HARNESS_ROOT:-}" ] && rm -rf "$HARNESS_ROOT"
+}
+trap cleanup_all EXIT INT TERM
 
 # Defensive precondition: ensure harness root is NOT inside a git worktree.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
@@ -46,14 +54,13 @@ if git -C "$HARNESS_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 2
 fi
 
-cleanup_all() {
-  cd / 2>/dev/null || true
-  [ -n "${HARNESS_ROOT:-}" ] && rm -rf "$HARNESS_ROOT"
-}
-trap cleanup_all EXIT INT TERM
-
 make_work_dir() {
-  mktemp -d "$HARNESS_ROOT/wd.XXXXXX"
+  local wd
+  wd=$(mktemp -d "$HARNESS_ROOT/wd.XXXXXX") || {
+    printf 'FATAL: mktemp failed\n' >&2
+    exit 2
+  }
+  printf '%s\n' "$wd"
 }
 
 make_test_repo() {

--- a/tests/hooks.test.sh
+++ b/tests/hooks.test.sh
@@ -663,7 +663,8 @@ section "[STOP-PEER-REVIEW-GATE-7] allows outside a git worktree"
 
 section "[STOP-PEER-REVIEW-GATE-8] fail-open on malformed stdin"
 {
-  CLAUDE_STATE_DIR="$(make_work_dir)/state"
+  _wd="$(make_work_dir)" || exit 2
+  CLAUDE_STATE_DIR="$_wd/state"
   export CLAUDE_STATE_DIR
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -965,7 +966,8 @@ section "[RECORD-SUBAGENT-RUN] ignores other subagents"
 
 section "[RECORD-SUBAGENT-RUN] fail-open on malformed stdin"
 {
-  CLAUDE_STATE_DIR="$(make_work_dir)/state"
+  _wd="$(make_work_dir)" || exit 2
+  CLAUDE_STATE_DIR="$_wd/state"
   export CLAUDE_STATE_DIR
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1617,7 +1619,7 @@ section "[EDGE-D1] dispatch handles paths with spaces in root"
 {
   # Create temp dir WITH spaces in path (under HARNESS_ROOT, preserving space property)
   # mktemp creates the base, then we add the space-containing subdirectory
-  base="$(make_work_dir)"
+  base="$(make_work_dir)" || exit 2
   root_with_spaces="$base/space test root"
   mkdir -p "$root_with_spaces/hooks"
   cp "$SRC_REPO/hooks/dispatch.sh" "$root_with_spaces/hooks/" 2>/dev/null || true
@@ -1673,7 +1675,7 @@ section "[EDGE-D1-CHAIN] dispatch chain-quoting: spaces in path correctly tokeni
 {
   # Test that spaced root path is correctly handled in shell chain context
   # This validates the ${0%[\\/]*} separator-strip logic on a spaced absolute path
-  base="$(make_work_dir)"
+  base="$(make_work_dir)" || exit 2
   root_with_spaces="$base/space test chain"
   mkdir -p "$root_with_spaces/hooks"
   cp "$SRC_REPO/hooks/dispatch.sh" "$root_with_spaces/hooks/" 2>/dev/null || true

--- a/tests/hooks.test.sh
+++ b/tests/hooks.test.sh
@@ -132,7 +132,7 @@ printf '%s================================================%s\n' "$C_CYN" "$C_NC"
 
 section "[DISPATCH-A] Unknown hook name → exit 0, empty output"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   cp "$SRC_REPO/hooks/dispatch.sh" "$workdir/" 2>/dev/null || true
 
   if [ -f "$workdir/dispatch.sh" ]; then
@@ -147,7 +147,7 @@ section "[DISPATCH-A] Unknown hook name → exit 0, empty output"
 
 section "[DISPATCH-B] Empty/missing hook name → exit 0, empty output"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   cp "$SRC_REPO/hooks/dispatch.sh" "$workdir/" 2>/dev/null || true
 
   if [ -f "$workdir/dispatch.sh" ]; then
@@ -162,7 +162,7 @@ section "[DISPATCH-B] Empty/missing hook name → exit 0, empty output"
 
 section "[DISPATCH-C1] platform-aware routing: MSYS arm vs Linux sh arm"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/hooks"
   cp "$SRC_REPO/hooks/dispatch.sh" "$workdir/hooks/" 2>/dev/null || true
 
@@ -218,7 +218,7 @@ SHFAKE
 
 section "[DISPATCH-C2] sh-arm routing via fake uname"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/hooks" "$workdir/bin"
   cp "$SRC_REPO/hooks/dispatch.sh" "$workdir/hooks/" 2>/dev/null || true
 
@@ -261,7 +261,7 @@ SHARM
 
 section "[DISPATCH-D] dispatch always exits 0 even if child fails"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/hooks"
   cp "$SRC_REPO/hooks/dispatch.sh" "$workdir/hooks/" 2>/dev/null || true
 
@@ -306,7 +306,7 @@ section "[DISPATCH-E] No CR byte in all *.sh files"
 
 section "[SESSION-START-CONTEXT] ahead-of-base on feature branch"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/test_repo"
   testgit="$workdir/test_repo"
 
@@ -344,7 +344,7 @@ section "[SESSION-START-CONTEXT] ahead-of-base on feature branch"
 
 section "[SESSION-START-CONTEXT] base-branch state on main"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/test_repo"
   testgit="$workdir/test_repo"
 
@@ -379,7 +379,7 @@ section "[SESSION-START-CONTEXT] base-branch state on main"
 section "[SESSION-START-CONTEXT] silent outside a git worktree"
 {
   # Create temp dir OUTSIDE the repo (under HARNESS_ROOT, safe from repo mutations)
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
 
   # Test outside git worktree
   test_payload="{\"session_id\":\"s3\",\"cwd\":\"$workdir\"}"
@@ -403,7 +403,7 @@ section "[SESSION-START-CONTEXT] fail-open on malformed stdin"
 
 section "[PRETOOLUSE-DELEGATION-HINT] suggests rust-expert for .rs file"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
 
   # Set CLAUDE_STATE_DIR for this test to isolate state
   export CLAUDE_STATE_DIR="$workdir/state"
@@ -432,7 +432,7 @@ section "[PRETOOLUSE-DELEGATION-HINT] suggests rust-expert for .rs file"
 
 section "[PRETOOLUSE-DELEGATION-HINT] hints at most once per session per agent"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
 
   # Set CLAUDE_STATE_DIR for this test
   export CLAUDE_STATE_DIR="$workdir/state"
@@ -461,7 +461,7 @@ section "[PRETOOLUSE-DELEGATION-HINT] hints at most once per session per agent"
 
 section "[PRETOOLUSE-DELEGATION-HINT] silent for unmapped extensions"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
 
   # Set CLAUDE_STATE_DIR for this test
   export CLAUDE_STATE_DIR="$workdir/state"
@@ -489,7 +489,7 @@ section "[PRETOOLUSE-DELEGATION-HINT] fail-open on malformed stdin"
 
 section "[STOP-PEER-REVIEW-GATE-1] loop-safety: stop_hook_active=true allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -510,7 +510,7 @@ section "[STOP-PEER-REVIEW-GATE-1] loop-safety: stop_hook_active=true allows"
 
 section "[STOP-PEER-REVIEW-GATE-2] blocks: feature branch ahead, clean tree, no marker"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -540,7 +540,7 @@ section "[STOP-PEER-REVIEW-GATE-2] blocks: feature branch ahead, clean tree, no 
 
 section "[STOP-PEER-REVIEW-GATE-3] fires at most once per session (.fired marker)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -571,7 +571,7 @@ section "[STOP-PEER-REVIEW-GATE-3] fires at most once per session (.fired marker
 
 section "[STOP-PEER-REVIEW-GATE-4] allows when peer-review marker exists (legacy)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -595,7 +595,7 @@ section "[STOP-PEER-REVIEW-GATE-4] allows when peer-review marker exists (legacy
 
 section "[STOP-PEER-REVIEW-GATE-5] allows when working tree is dirty"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -619,7 +619,7 @@ section "[STOP-PEER-REVIEW-GATE-5] allows when working tree is dirty"
 
 section "[STOP-PEER-REVIEW-GATE-6] allows on base branch (main)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -643,7 +643,7 @@ section "[STOP-PEER-REVIEW-GATE-6] allows on base branch (main)"
 
 section "[STOP-PEER-REVIEW-GATE-7] allows outside a git worktree"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   non_git="$workdir/not_a_repo"
   mkdir -p "$non_git"
 
@@ -678,7 +678,7 @@ section "[STOP-PEER-REVIEW-GATE-8] fail-open on malformed stdin"
 
 section "[STOP-PEER-REVIEW-GATE-R7a] 3-line marker with verdict=APPROVED allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -705,7 +705,7 @@ section "[STOP-PEER-REVIEW-GATE-R7a] 3-line marker with verdict=APPROVED allows"
 
 section "[STOP-PEER-REVIEW-GATE-R7b] 3-line marker with verdict=CHANGES_REQUIRED blocks"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -736,7 +736,7 @@ section "[STOP-PEER-REVIEW-GATE-R7b] 3-line marker with verdict=CHANGES_REQUIRED
 
 section "[STOP-PEER-REVIEW-GATE-g1] allows on verdict=APPROVED marker"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -760,7 +760,7 @@ section "[STOP-PEER-REVIEW-GATE-g1] allows on verdict=APPROVED marker"
 
 section "[STOP-PEER-REVIEW-GATE-g2] verdict=CHANGES_REQUIRED blocks with 3-call budget"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -819,7 +819,7 @@ section "[STOP-PEER-REVIEW-GATE-g2] verdict=CHANGES_REQUIRED blocks with 3-call 
 
 section "[STOP-PEER-REVIEW-GATE-g2-approved] later APPROVED marker allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -853,7 +853,7 @@ section "[STOP-PEER-REVIEW-GATE-g2-approved] later APPROVED marker allows"
 
 section "[STOP-PEER-REVIEW-GATE-g3] legacy empty .fired counts as 1 block"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -900,7 +900,7 @@ section "[STOP-PEER-REVIEW-GATE-g3] legacy empty .fired counts as 1 block"
 
 section "[RECORD-SUBAGENT-RUN] writes marker for peer-review-critic run"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -921,7 +921,7 @@ section "[RECORD-SUBAGENT-RUN] writes marker for peer-review-critic run"
 
 section "[RECORD-SUBAGENT-RUN] marker without report text carries no verdict line"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -944,7 +944,7 @@ section "[RECORD-SUBAGENT-RUN] marker without report text carries no verdict lin
 
 section "[RECORD-SUBAGENT-RUN] ignores other subagents"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -979,7 +979,7 @@ section "[RECORD-SUBAGENT-RUN] fail-open on malformed stdin"
 
 section "[RECORD-SUBAGENT-RUN] parses verdict from string tool_response"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1002,7 +1002,7 @@ section "[RECORD-SUBAGENT-RUN] parses verdict from string tool_response"
 
 section "[RECORD-SUBAGENT-RUN] parses verdict from content-array tool_response"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1025,7 +1025,7 @@ section "[RECORD-SUBAGENT-RUN] parses verdict from content-array tool_response"
 
 section "[RECORD-SUBAGENT-RUN] SubagentStop path records verdict"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1048,7 +1048,7 @@ section "[RECORD-SUBAGENT-RUN] SubagentStop path records verdict"
 
 section "[RECORD-SUBAGENT-RUN] SubagentStop ignores other agent types"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1069,7 +1069,7 @@ section "[RECORD-SUBAGENT-RUN] SubagentStop ignores other agent types"
 
 section "[RECORD-SUBAGENT-RUN] SubagentStop ignores otherplugin:peer-review-critic"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1090,7 +1090,7 @@ section "[RECORD-SUBAGENT-RUN] SubagentStop ignores otherplugin:peer-review-crit
 
 section "[RECORD-SUBAGENT-RUN] last VERDICT occurrence wins"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1113,7 +1113,7 @@ section "[RECORD-SUBAGENT-RUN] last VERDICT occurrence wins"
 
 section "[RECORD-SUBAGENT-RUN] re-review overwrites marker"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1140,7 +1140,7 @@ section "[RECORD-SUBAGENT-RUN] re-review overwrites marker"
 
 section "[RECORD-SUBAGENT-RUN] no-downgrade: verdict-less event preserves CHANGES_REQUIRED"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1166,7 +1166,7 @@ section "[RECORD-SUBAGENT-RUN] no-downgrade: verdict-less event preserves CHANGE
 
 section "[RECORD-SUBAGENT-RUN] parses verdict from bare-array tool_response"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1189,7 +1189,7 @@ section "[RECORD-SUBAGENT-RUN] parses verdict from bare-array tool_response"
 
 section "[RECORD-SUBAGENT-RUN] falls back to tool_output when tool_response absent"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1212,7 +1212,7 @@ section "[RECORD-SUBAGENT-RUN] falls back to tool_output when tool_response abse
 
 section "[RECORD-SUBAGENT-RUN] parses verdict from CRLF report text"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1236,7 +1236,7 @@ section "[RECORD-SUBAGENT-RUN] parses verdict from CRLF report text"
 
 section "[RECORD-SUBAGENT-RUN] mid-line quoted verdict does not count"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1260,7 +1260,7 @@ section "[RECORD-SUBAGENT-RUN] mid-line quoted verdict does not count"
 
 section "[RECORD-SUBAGENT-RUN-R1] instance dedupe: same id does not overwrite APPROVED"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1294,7 +1294,7 @@ section "[RECORD-SUBAGENT-RUN-R1] instance dedupe: same id does not overwrite AP
 
 section "[RECORD-SUBAGENT-RUN-R2] instance dedupe: same id does not bypass (CHANGES_REQUIRED)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1325,7 +1325,7 @@ section "[RECORD-SUBAGENT-RUN-R2] instance dedupe: same id does not bypass (CHAN
 
 section "[RECORD-SUBAGENT-RUN-R3] different ids at same HEAD, latest wins"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1356,7 +1356,7 @@ section "[RECORD-SUBAGENT-RUN-R3] different ids at same HEAD, latest wins"
 
 section "[RECORD-SUBAGENT-RUN-R4] id-less same-HEAD contradiction guard"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1414,7 +1414,7 @@ section "[RECORD-SUBAGENT-RUN-R4] id-less same-HEAD contradiction guard"
 
 section "[RECORD-SUBAGENT-RUN-R5] id-absent, HEAD MOVES → verdicts can change"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1455,7 +1455,7 @@ section "[RECORD-SUBAGENT-RUN-R5] id-absent, HEAD MOVES → verdicts can change"
 
 section "[RECORD-SUBAGENT-RUN-R6] tool_use_id dedupe and no-downgrade"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1503,7 +1503,7 @@ section "[RECORD-SUBAGENT-RUN-R6] tool_use_id dedupe and no-downgrade"
 
 section "[RECORD-SUBAGENT-RUN-R7] HEAD-qualified instance dedupe"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1546,7 +1546,7 @@ section "[RECORD-SUBAGENT-RUN-R7] HEAD-qualified instance dedupe"
 
 section "[RECORD-SUBAGENT-RUN-R8] same id, same HEAD suppressed"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1587,7 +1587,7 @@ section "[RECORD-SUBAGENT-RUN-R8] same id, same HEAD suppressed"
 
 section "[RECORD-SUBAGENT-RUN] plugin-scoped agentic-framework:peer-review-critic"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1743,7 +1743,7 @@ SPACEPS
 
 section "[INTEGRATION-R1] record-subagent-run APPROVED → stop-peer-review-gate allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1779,7 +1779,7 @@ section "[INTEGRATION-R1] record-subagent-run APPROVED → stop-peer-review-gate
 
 section "[INTEGRATION-V6] record-subagent-run CHANGES_REQUIRED, verdict-less re-emission → gate still blocks"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1817,7 +1817,7 @@ section "[INTEGRATION-V6] record-subagent-run CHANGES_REQUIRED, verdict-less re-
 
 section "[INTEGRATION-G4] CR verdict → gate blocks; later APPROVED → gate allows"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   testgit="$workdir/test_repo"
   mkdir -p "$testgit"
   make_test_repo "$testgit"
@@ -1860,7 +1860,7 @@ section "[INTEGRATION-G4] CR verdict → gate blocks; later APPROVED → gate al
 
 section "[INTEGRATION-IMPOSTOR] agent-name enforcement: agentic-framework:impostor-agent not recorded"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1881,7 +1881,7 @@ section "[INTEGRATION-IMPOSTOR] agent-name enforcement: agentic-framework:impost
 
 section "[INTEGRATION-ABSENT-PLUGIN] otherplugin:some-agent absent from registry → handled gracefully"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   export CLAUDE_STATE_DIR="$workdir/state"
   mkdir -p "$CLAUDE_STATE_DIR/peer-review"
 
@@ -1901,22 +1901,13 @@ section "[INTEGRATION-ABSENT-PLUGIN] otherplugin:some-agent absent from registry
 
 section "[GATE-PRECEDENCE] dual verdict in marker: CHANGES_REQUIRED wins over APPROVED (fail-closed)"
 {
-  workdir="$(make_work_dir)"
+  workdir="$(make_work_dir)" || exit 2
   mkdir -p "$workdir/test_repo" "$workdir/state/peer-review"
   testgit="$workdir/test_repo"
   export CLAUDE_STATE_DIR="$workdir/state"
 
-  # Build test repo
-  git -C "$testgit" init -q -b main
-  git -C "$testgit" config user.email 'test@test.local'
-  git -C "$testgit" config user.name 'hooks-test'
-  printf 'one\n' > "$testgit/a.txt"
-  git -C "$testgit" add -A
-  git -C "$testgit" commit -q -m 'init'
-  git -C "$testgit" checkout -q -b feature/x
-  printf 'two\n' > "$testgit/b.txt"
-  git -C "$testgit" add -A
-  git -C "$testgit" commit -q -m 'feature work'
+  # Build test repo using the shared function (with safety guard for failed git init)
+  make_test_repo "$testgit"
 
   # Create marker with BOTH lines (APPROVED first, to prove CHANGES_REQUIRED still wins)
   marker_file="$CLAUDE_STATE_DIR/peer-review/precedence-test"

--- a/tests/hooks.test.sh
+++ b/tests/hooks.test.sh
@@ -31,8 +31,16 @@ TESTS_FAIL=0
 # Create a single mktemp-based harness root for all test fixtures.
 # All temp dirs are created under this single root; cleanup_all removes
 # it wholesale. This eliminates PID-based naming collision issues and
-# ensures predictable cleanup across concurrent runs.
+# ensures predictable cleanup across concurrent runs (a prior incident:
+# a shared/global glob pattern caused one test-harness instance to delete
+# another CONCURRENT instance's live fixture directories mid-run).
 HARNESS_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/hooks-test.XXXXXXXX") || exit 1
+
+cleanup_all() {
+  cd / 2>/dev/null || true
+  [ -n "${HARNESS_ROOT:-}" ] && rm -rf "$HARNESS_ROOT"
+}
+trap cleanup_all EXIT INT TERM
 
 # Defensive precondition: ensure harness root is NOT inside a git worktree.
 # This belt-and-suspenders check prevents test dirs from mutating the repo
@@ -43,17 +51,16 @@ if git -C "$HARNESS_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 2
 fi
 
-cleanup_all() {
-  cd / 2>/dev/null || true
-  [ -n "${HARNESS_ROOT:-}" ] && rm -rf "$HARNESS_ROOT"
-}
-trap cleanup_all EXIT INT TERM
-
 # --- temp dir and repo helpers ─────────────────────────────────────────────
 make_work_dir() {
   # Create a throwaway temp directory under HARNESS_ROOT for test fixtures.
   # All test subdirectories are created here, ensuring proper isolation.
-  mktemp -d "$HARNESS_ROOT/wd.XXXXXX"
+  local wd
+  wd=$(mktemp -d "$HARNESS_ROOT/wd.XXXXXX") || {
+    printf 'FATAL: mktemp failed\n' >&2
+    exit 2
+  }
+  printf '%s\n' "$wd"
 }
 
 make_test_repo() {
@@ -1886,6 +1893,53 @@ section "[INTEGRATION-ABSENT-PLUGIN] otherplugin:some-agent absent from registry
     _pass "INTEGRATION-ABSENT-PLUGIN: no marker created (agent not in registry)"
   else
     _fail "INTEGRATION-ABSENT-PLUGIN: should ignore" "unexpected marker created"
+  fi
+
+  unset CLAUDE_STATE_DIR
+  rm -rf "$workdir"
+}
+
+section "[GATE-PRECEDENCE] dual verdict in marker: CHANGES_REQUIRED wins over APPROVED (fail-closed)"
+{
+  workdir="$(make_work_dir)"
+  mkdir -p "$workdir/test_repo" "$workdir/state/peer-review"
+  testgit="$workdir/test_repo"
+  export CLAUDE_STATE_DIR="$workdir/state"
+
+  # Build test repo
+  git -C "$testgit" init -q -b main
+  git -C "$testgit" config user.email 'test@test.local'
+  git -C "$testgit" config user.name 'hooks-test'
+  printf 'one\n' > "$testgit/a.txt"
+  git -C "$testgit" add -A
+  git -C "$testgit" commit -q -m 'init'
+  git -C "$testgit" checkout -q -b feature/x
+  printf 'two\n' > "$testgit/b.txt"
+  git -C "$testgit" add -A
+  git -C "$testgit" commit -q -m 'feature work'
+
+  # Create marker with BOTH lines (APPROVED first, to prove CHANGES_REQUIRED still wins)
+  marker_file="$CLAUDE_STATE_DIR/peer-review/precedence-test"
+  {
+    printf 'verdict=APPROVED\n'
+    printf 'verdict=CHANGES_REQUIRED\n'
+  } > "$marker_file"
+
+  # Run gate hook with ahead-of-base scenario
+  test_payload="{\"session_id\":\"precedence-test\",\"cwd\":\"$testgit\",\"stop_hook_active\":false}"
+  RUN_OUT="$(printf '%s' "$test_payload" | sh "$SRC_REPO/hooks/stop-peer-review-gate.sh" 2>&1)"
+  RUN_RC=$?
+
+  assert_rc_zero "GATE-PRECEDENCE: hook exits 0 (always returns decision JSON)"
+  if printf '%s' "$RUN_OUT" | grep -q '"decision":"block"'; then
+    _pass "GATE-PRECEDENCE: correctly blocks (CHANGES_REQUIRED precedence)"
+  else
+    _fail "GATE-PRECEDENCE: should block" "expected decision:block, got: $RUN_OUT"
+  fi
+  if printf '%s' "$RUN_OUT" | grep -q 'CHANGES_REQUIRED'; then
+    _pass "GATE-PRECEDENCE: reason mentions CHANGES_REQUIRED (not APPROVED)"
+  else
+    _fail "GATE-PRECEDENCE: reason string" "expected CHANGES_REQUIRED mention, got: $RUN_OUT"
   fi
 
   unset CLAUDE_STATE_DIR

--- a/tests/migrate.test.ps1
+++ b/tests/migrate.test.ps1
@@ -319,19 +319,19 @@ Remove-Item -Recurse -Force $workRoot -ErrorAction SilentlyContinue
 $workRoot   = Join-Path ([IO.Path]::GetTempPath()) ("migrate-test-" + [guid]::NewGuid().ToString('N'))
 $sandboxDir = Join-Path $workRoot 'home'
 $claudeHome = Join-Path $sandboxDir '.claude'
-$claudeJson = Join-Path $sandboxDir '.claude.json'
 New-Item -ItemType Directory -Force -Path $claudeHome | Out-Null
 
 # Create a minimal config for the test
 $settings = @{ hooks = @{} }
 $settings | ConvertTo-Json -Depth 16 | Set-Content (Join-Path $claudeHome 'settings.json') -NoNewline
-'{"test":"data"}' | Set-Content $claudeJson -NoNewline
+'{"test":"data"}' | Set-Content (Join-Path $claudeHome 'claude.json') -NoNewline
 
 # Initialize git repo and track a file
 $gitDir = Join-Path $claudeHome '.git'
 git -C $claudeHome init 2>$null | Out-Null
 git -C $claudeHome config user.email "test@test.local" 2>$null
 git -C $claudeHome config user.name "Test" 2>$null
+git -C $claudeHome config core.safecrlf false 2>$null
 $trackFile = Join-Path $claudeHome 'agents' 'dummy.md'
 New-Item -ItemType Directory -Force -Path (Split-Path $trackFile -Parent) | Out-Null
 'agent' | Set-Content $trackFile -NoNewline
@@ -351,10 +351,20 @@ New-Item -ItemType Directory -Force -Path (Join-Path $claudeHome 'todos') | Out-
 git -C $claudeHome add -A 2>$null
 git -C $claudeHome commit -m "protected" 2>$null | Out-Null
 
-$r = Invoke-Migrator $claudeHome -ExtraArgs @('-Apply')
+# Create a bare remote repo and push commits (so they're not "unpushed")
+$remoteDir = Join-Path $workRoot 'remote.git'
+git init --bare $remoteDir 2>$null | Out-Null
+git -C $claudeHome remote add origin $remoteDir 2>$null
+# Get current branch name (could be master or main depending on git version)
+$branch = git -C $claudeHome rev-parse --abbrev-ref HEAD 2>$null
+git -C $claudeHome push -u origin $branch 2>$null | Out-Null
+
+# Run in dry-run mode first to verify summary is generated correctly
+$r = Invoke-Migrator $claudeHome
 
 Assert 'checkout cleanup runs' ($r.Code -eq 0)
 Assert 'checkout cleanup detects repo' ($r.Out -imatch 'Checkout Cleanup|detected|git clone')
+Assert 'checkout summary row present' ($r.Out -match 'checkout:\s+\d+\s+tracked file\(s\),\s+\.git')
 Assert '.state preserved' ((Test-Path (Join-Path $claudeHome '.state' 'marker.txt')))
 Assert 'settings.local.json preserved' ((Test-Path (Join-Path $claudeHome 'settings.local.json')))
 Assert 'projects dir preserved' ((Test-Path (Join-Path $claudeHome 'projects' 'myp' 'file.txt')))

--- a/tests/migrate.test.ps1
+++ b/tests/migrate.test.ps1
@@ -364,7 +364,8 @@ $r = Invoke-Migrator $claudeHome
 
 Assert 'checkout cleanup runs' ($r.Code -eq 0)
 Assert 'checkout cleanup detects repo' ($r.Out -imatch 'Checkout Cleanup|detected|git clone')
-Assert 'checkout summary row present' ($r.Out -match 'checkout:\s+\d+\s+tracked file\(s\),\s+\.git')
+# This assertion only covers the dry-run path; the apply+success path (where the regression originally occurred) is not exercised by this fixture because -Apply aborts before reaching that code (backup step dirties tree before Section 5 check).
+Assert 'checkout summary row present (dry-run path)' ($r.Out -match 'checkout:\s+\d+\s+tracked file\(s\),\s+\.git')
 Assert '.state preserved' ((Test-Path (Join-Path $claudeHome '.state' 'marker.txt')))
 Assert 'settings.local.json preserved' ((Test-Path (Join-Path $claudeHome 'settings.local.json')))
 Assert 'projects dir preserved' ((Test-Path (Join-Path $claudeHome 'projects' 'myp' 'file.txt')))


### PR DESCRIPTION
## Summary
A batch of small, non-blocking hardening/polish items deferred as follow-ups during the bash-hooks feature review (now merged in #29) and the earlier plugin-pipeline review (#28):

- hookcheck.sh's dispatch-allowlist parser: fixed a no-op grep pattern
- new validator check: intra-chain name coherence (dispatch.sh arg name must match the .ps1 filename stem in every hooks.json chain)
- test harness: trap-registration ordering fix (no more leaked temp dirs on the defensive precondition's abort path)
- test harness: mktemp-failure guard at make_work_dir call sites
- test harness: restored historical context comment on why directory-scoping exists
- new permanent regression test locking in the Stop gate's fail-closed dual-verdict-token precedence (previously verified only by manual review)
- new macOS CI job running the POSIX hook suite on genuine BSD userland (closes the last named target-platform gap)
- validate-hooks.sh: refreshed stale header/success-message text to describe the pair+dispatch model
- deleted a stray gitignored debug file
- migrate-legacy.ps1: fixed an abort-path summary that got overwritten by a later unconditional message
- setup.md: portable (non-bash-specific) shell syntax in the token-entry examples, plus a missing fish example

## Test plan
Full battery green: hooks.test.sh (146), hooks-equivalence.test.sh (15), validate-consistency.sh, plugin-manifests.test.sh (31), security-check.sh, hooks.test.ps1, migrate.test.ps1, install.test.ps1, generate-docs.sh --check.