### PR TITLE
fix: resolve final peer-review findings (round 2)

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Run hooks test harness (macOS/POSIX)
         run: bash tests/hooks.test.sh
 
+      # tests/consistency.test.sh is deliberately NOT run here: it uses a GNU-only
+      # `sed -i` (no backup suffix) at line ~261, which BSD sed rejects; the
+      # portable form is already used elsewhere in that file (see ~line 454).
       - name: Cross-impl equivalence (sh only; pwsh unavailable on macOS)
         # tests/hooks-equivalence.test.sh self-skips if pwsh is unavailable;
         # running it here documents .sh-only equivalence and validates the self-skip

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -113,6 +113,17 @@ jobs:
       - name: Run hooks test harness (macOS/POSIX)
         run: bash tests/hooks.test.sh
 
+      - name: Cross-impl equivalence (sh only; pwsh unavailable on macOS)
+        # tests/hooks-equivalence.test.sh self-skips if pwsh is unavailable;
+        # running it here documents .sh-only equivalence and validates the self-skip
+        run: bash tests/hooks-equivalence.test.sh
+
+      - name: Plugin manifest tests (pure bash/jq)
+        run: bash tests/plugin-manifests.test.sh
+
+      - name: Check generated docs are fresh (pure bash/jq)
+        run: bash scripts/generate-docs.sh --check
+
   hooks-windows:
     name: hook behavior + validators (windows)
     runs-on: windows-latest

--- a/commands/analyze-framework.md
+++ b/commands/analyze-framework.md
@@ -76,7 +76,7 @@ Analyzes every registered agent using the canonical categories from `${CLAUDE_PL
 
 Hooks are real Claude Code hooks: .ps1/.sh script pairs in `${CLAUDE_PLUGIN_ROOT}/hooks/`, routed by `${CLAUDE_PLUGIN_ROOT}/hooks/dispatch.sh`, registered in `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` as shell-form dispatch chains.
 
-- Pair parity: every registered hook name has both .ps1 and .sh implementations; dispatch.sh is present and referenced in every registered chain; no orphans on either side (check 3). The name allowlist inside dispatch.sh is not validator-checked.
+- Pair parity: every registered hook name has both .ps1 and .sh implementations; dispatch.sh is present and referenced in every registered chain; no orphans on either side (check 3). The name allowlist inside dispatch.sh is validator-checked: every registered hook name must appear in the case statement pattern.
 - Behavior: `${CLAUDE_PLUGIN_ROOT}/tests/hooks.test.ps1` (PowerShell suite) and `${CLAUDE_PLUGIN_ROOT}/tests/hooks.test.sh` (POSIX suite) exercise block/allow paths of the peer-review Stop gate, the run recorder, session context, and the delegation hint on both implementations
 - Design rationale: `${CLAUDE_PLUGIN_ROOT}/docs/design/`
 

--- a/commands/quality-report.md
+++ b/commands/quality-report.md
@@ -46,7 +46,7 @@ Check agent ecosystem completeness:
 ### 3. Hook Architecture
 
 Assess the real hook system:
-- Pair parity: every hook name in `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` has both .ps1 and .sh implementations; dispatch.sh is present and referenced in every registered chain; no orphans on either side (the dispatch.sh name allowlist itself is not validator-checked)
+- Pair parity: every hook name in `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` has both .ps1 and .sh implementations; dispatch.sh is present and referenced in every registered chain; no orphans on either side. The name allowlist inside dispatch.sh is validator-checked: every registered hook name must appear in the case statement pattern
 - All event names are valid Claude Code hook events; all .ps1 scripts pin PowerShell 7; all .sh scripts have proper shebang and `set -u`
 - Hook behavior tests pass (`${CLAUDE_PLUGIN_ROOT}/tests/hooks.test.ps1` and `${CLAUDE_PLUGIN_ROOT}/tests/hooks.test.sh`)
 - No references to deprecated agent names

--- a/commands/validate-hooks.md
+++ b/commands/validate-hooks.md
@@ -51,11 +51,12 @@ FRAMEWORK_ROOT="${CLAUDE_PLUGIN_ROOT:-.}" bash "${CLAUDE_PLUGIN_ROOT:-.}/scripts
 It asserts:
 
 1. **Pair parity** — every hook name registered in `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` has both `.ps1` and `.sh` implementations on disk; every `.ps1` and `.sh` on disk is registered (no orphans on either side).
-2. **Dispatch presence** — `${CLAUDE_PLUGIN_ROOT}/hooks/dispatch.sh` exists and is referenced in every registered hook chain. (The name allowlist inside dispatch.sh itself is NOT validator-checked — keep it in sync by hand when adding a hook.)
+2. **Dispatch presence** — `${CLAUDE_PLUGIN_ROOT}/hooks/dispatch.sh` exists and is referenced in every registered hook chain. The name allowlist inside dispatch.sh is validator-checked: every registered hook name must appear in the case statement pattern.
 3. **Event validity** — every event key is a real Claude Code hook event (`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`, `PreCompact`).
 4. **PowerShell pin** — every `.ps1` script starts with `#Requires -Version 7.0`.
 5. **Shell pins** — every `.sh` script starts with `#!/bin/sh` (shebang) and has `set -u` (second line).
-6. **No deprecated agent names** referenced by any hook script.
+6. **Dispatch chain coherence** — in each hook chain, the dispatch-shell argument matches the `.ps1` filename stem.
+7. **No deprecated agent names** referenced by any hook script.
 
 ## Behavior Validation (--behavior)
 
@@ -78,11 +79,11 @@ Hook Architecture Validation
 
 Checking hook registration parity (hooks/hooks.json <-> hooks/*.ps1)...
 
-OK: 4 hook script(s) registered across 5 event(s); no orphans; all events valid; all pin PS7
+OK: 4 .ps1 + 5 .sh hook script(s) registered across 5 event(s); dispatch chains coherent; all events valid
 
 Checking for deprecated agent references in hooks/...
 
-OK: no deprecated agent references found
+OK: no deprecated agent references found (checked 7 names)
 
 ================================
 Hook validation passed

--- a/mcp-plugin/commands/setup.md
+++ b/mcp-plugin/commands/setup.md
@@ -92,7 +92,7 @@ try {
 
 ```bash
 # EXAMPLE: Copy and paste this into YOUR OWN terminal:
-# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and ksh; read -s is a shell extension, not POSIX — dash/ash don't support it)
+# EXAMPLE: Secure token capture and persistence (works on bash and zsh; read -s is a shell extension, not POSIX — dash/ash don't support it; note ksh's -s means "save to history", not silence — so this snippet is NOT safe under ksh)
 printf 'Paste your Context7 API key: '
 read -r -s C7KEY
 printf '\n'
@@ -195,7 +195,7 @@ Detect the user's login shell and append to its profile (with guard to prevent d
 
 ```bash
 # EXAMPLE: Option C - Validate and persist token (user provides in chat)
-# EXAMPLE: Secure token capture and persistence (works on bash, zsh, and ksh; read -s is a shell extension, not POSIX — dash/ash don't support it)
+# EXAMPLE: Secure token capture and persistence (works on bash and zsh; read -s is a shell extension, not POSIX — dash/ash don't support it; note ksh's -s means "save to history", not silence — so this snippet is NOT safe under ksh)
 printf 'Paste your Context7 API key: '
 read -r -s C7KEY
 printf '\n'

--- a/scripts/lib/hookcheck.sh
+++ b/scripts/lib/hookcheck.sh
@@ -182,6 +182,9 @@ hookcheck_problems() {
     # Extract dispatch-arg: the word after dispatch.sh (may be quoted or bare)
     dispatch_arg=$(printf '%s' "$cmd" | sed -n 's/.*dispatch\.sh[[:space:]]*["'"'"']\{0,1\}[[:space:]]*\([^"'"'"' ][^ ]*\).*/\1/p')
     # Extract .ps1 filename: the basename after -File argument (look for -File context, not greedy from start)
+    # NOTE: This regex requires the .ps1 path to be double-quoted (e.g., -File "...name.ps1").
+    # Unquoted or single-quoted forms will not match and the check silently no-ops (acceptable
+    # since hooks.json is generated/controlled).
     ps1_path=$(printf '%s' "$cmd" | sed -n 's/.*-File[[:space:]]*"\([^"]*\.ps1\)".*/\1/p')
     ps1_file=$(basename "$ps1_path" 2>/dev/null)
     ps1_stem="${ps1_file%.ps1}"
@@ -190,4 +193,5 @@ hookcheck_problems() {
       printf 'chain-name-mismatch\t%s (dispatch: %s vs .ps1: %s)\n' "$cmd" "$dispatch_arg" "$ps1_stem"
     fi
   done
+  return 0
 }

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -209,9 +209,10 @@ section "[3] Hook registration parity (hooks/hooks.json <-> hooks/*.ps1)"
       esac
     done <<< "$problems"
   else
-    n_scripts="$(fact_hook_script_files | grep -c . || true)"
+    n_ps1="$(fact_hook_script_files | grep -c . || true)"
+    n_sh="$(fact_hook_sh_impl_files | grep -c . || true)"
     n_events="$(fact_hook_events | grep -c . || true)"
-    pass "$n_scripts hook script(s) registered across $n_events event(s); parity OK (both .ps1 and .sh), all events valid, all pin PS7"
+    pass "$n_ps1 .ps1 + $n_sh .sh hook script(s) registered across $n_events event(s); dispatch chains coherent; all events valid"
   fi
 }
 

--- a/tests/hooks.test.sh
+++ b/tests/hooks.test.sh
@@ -1903,10 +1903,12 @@ section "[INTEGRATION-ABSENT-PLUGIN] otherplugin:some-agent absent from registry
 
 # NOTE: [GATE-PRECEDENCE] tests the .sh-specific implementation detail that when a
 # marker file contains both verdict tokens (unreachable via the recorder's real
-# write path), the .sh version implements fail-closed (last-verdict-wins: CHANGES_REQUIRED
-# overrides APPROVED). The .ps1 twin uses first-match-wins parsing and may resolve the
-# same dual-token marker differently — this property is NOT asserted across implementations.
-# This test documents .sh behavior only and is not mirrored in hooks-equivalence.
+# write path), the .sh version implements fail-closed (CHANGES_REQUIRED is tested
+# first, regardless of which verdict line appears earlier in the file). The .ps1
+# twin uses first-match-wins parsing and does resolve the same dual-token marker
+# differently (measured: .sh blocks, .ps1 allows) — this property is NOT asserted
+# across implementations. This test documents .sh behavior only and is not mirrored
+# in hooks-equivalence.
 section "[GATE-PRECEDENCE] dual verdict in marker: CHANGES_REQUIRED wins over APPROVED (fail-closed)"
 {
   workdir="$(make_work_dir)" || exit 2

--- a/tests/hooks.test.sh
+++ b/tests/hooks.test.sh
@@ -1901,6 +1901,12 @@ section "[INTEGRATION-ABSENT-PLUGIN] otherplugin:some-agent absent from registry
   rm -rf "$workdir"
 }
 
+# NOTE: [GATE-PRECEDENCE] tests the .sh-specific implementation detail that when a
+# marker file contains both verdict tokens (unreachable via the recorder's real
+# write path), the .sh version implements fail-closed (last-verdict-wins: CHANGES_REQUIRED
+# overrides APPROVED). The .ps1 twin uses first-match-wins parsing and may resolve the
+# same dual-token marker differently — this property is NOT asserted across implementations.
+# This test documents .sh behavior only and is not mirrored in hooks-equivalence.
 section "[GATE-PRECEDENCE] dual verdict in marker: CHANGES_REQUIRED wins over APPROVED (fail-closed)"
 {
   workdir="$(make_work_dir)" || exit 2

--- a/tests/migrate.test.ps1
+++ b/tests/migrate.test.ps1
@@ -321,8 +321,8 @@ $sandboxDir = Join-Path $workRoot 'home'
 $claudeHome = Join-Path $sandboxDir '.claude'
 New-Item -ItemType Directory -Force -Path $claudeHome | Out-Null
 
-# Create a minimal config for the test
-$settings = @{ hooks = @{} }
+# Create a minimal config for the test (no hooks block, so nothing gets modified during migration)
+$settings = @{}
 $settings | ConvertTo-Json -Depth 16 | Set-Content (Join-Path $claudeHome 'settings.json') -NoNewline
 '{"test":"data"}' | Set-Content (Join-Path $claudeHome 'claude.json') -NoNewline
 
@@ -351,6 +351,11 @@ New-Item -ItemType Directory -Force -Path (Join-Path $claudeHome 'todos') | Out-
 git -C $claudeHome add -A 2>$null
 git -C $claudeHome commit -m "protected" 2>$null | Out-Null
 
+# Add .gitignore to exclude backup files (so they don't dirty the tree when migrator creates them)
+'*.bak-*' | Set-Content (Join-Path $claudeHome '.gitignore') -NoNewline
+git -C $claudeHome add .gitignore 2>$null
+git -C $claudeHome commit -m "add .gitignore" 2>$null | Out-Null
+
 # Create a bare remote repo and push commits (so they're not "unpushed")
 $remoteDir = Join-Path $workRoot 'remote.git'
 git init --bare $remoteDir 2>$null | Out-Null
@@ -359,13 +364,12 @@ git -C $claudeHome remote add origin $remoteDir 2>$null
 $branch = git -C $claudeHome rev-parse --abbrev-ref HEAD 2>$null
 git -C $claudeHome push -u origin $branch 2>$null | Out-Null
 
-# Run in dry-run mode first to verify summary is generated correctly
-$r = Invoke-Migrator $claudeHome
+# Run with -Apply to exercise the actual deletion logic and protected-path filtering
+$r = Invoke-Migrator $claudeHome -ExtraArgs @('-Apply')
 
 Assert 'checkout cleanup runs' ($r.Code -eq 0)
 Assert 'checkout cleanup detects repo' ($r.Out -imatch 'Checkout Cleanup|detected|git clone')
-# This assertion only covers the dry-run path; the apply+success path (where the regression originally occurred) is not exercised by this fixture because -Apply aborts before reaching that code (backup step dirties tree before Section 5 check).
-Assert 'checkout summary row present (dry-run path)' ($r.Out -match 'checkout:\s+\d+\s+tracked file\(s\),\s+\.git')
+Assert 'checkout summary row present (apply path)' ($r.Out -match 'checkout:\s+\d+\s+tracked file\(s\),\s+\.git')
 Assert '.state preserved' ((Test-Path (Join-Path $claudeHome '.state' 'marker.txt')))
 Assert 'settings.local.json preserved' ((Test-Path (Join-Path $claudeHome 'settings.local.json')))
 Assert 'projects dir preserved' ((Test-Path (Join-Path $claudeHome 'projects' 'myp' 'file.txt')))


### PR DESCRIPTION
## Summary
Fixes from the mandatory final peer review of the post-merge-followups batch (#30, already merged):

- **Security**: mcp-plugin/commands/setup.md's portable-shell claim incorrectly included ksh - ksh's `-s` flag means "save to history", not "silent", so the snippet would have leaked a captured token to $HISTFILE and the terminal under ksh. Removed the false claim.
- **Test coverage**: tests/migrate.test.ps1's Test 6 protected-path assertions (.state, settings.local.json, projects/, todos/) were structurally incapable of failing after an earlier round switched the test to dry-run mode. Fixed the fixture (a targeted .gitignore for backup files, removing an empty-hooks-block artifact) so the test now genuinely exercises the -Apply path and these assertions discriminate for real.
- **Doc drift**: commands/validate-hooks.md, analyze-framework.md, and quality-report.md still claimed the dispatch.sh allowlist is "not validator-checked" - false since an earlier round added a real check for it. Corrected, and added the missing 7th validator assertion (chain-name-mismatch) to the documented list, plus refreshed the stale sample output.
- **Test-scope clarity**: tests/hooks.test.sh's [GATE-PRECEDENCE] test enshrines a fail-closed property that is genuinely `.sh`-specific (the `.ps1` twin's first-match parsing differs for this edge case - a previously-reviewed-and-accepted, unreachable-in-practice divergence). Added comments making this scope explicit rather than implying a cross-implementation guarantee that doesn't exist.
- Minors: documented why the new macOS CI job omits tests/consistency.test.sh (a GNU-only sed -i there would break BSD sed), and added three more suites to that job that are safe/free (hooks-equivalence.test.sh self-skips without pwsh; plugin-manifests.test.sh and generate-docs.sh --check are pure bash/jq); a NOTE comment on the chain-name-mismatch check's quoting assumption; an explicit return 0 on hookcheck_problems(); aligned validate-consistency.sh's check-3 message with validate-hooks.sh's.

## Test plan
Full battery green: hooks.test.sh, hooks-equivalence.test.sh, validate-consistency.sh, validate-hooks.sh, plugin-manifests.test.sh, security-check.sh, hooks.test.ps1, migrate.test.ps1, install.test.ps1, generate-docs.sh --check.