### PR TITLE
docs: document install-flow findings from live rehearsal

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ When installing a plugin, use the full `<name>@<marketplace>` form where `<marke
 ```
 /plugin install agentic-framework@claude-agentic-framework
 ```
-Alternatively, once the marketplace is added, the bare plugin name also works: `/plugin install agentic-framework` (in this rehearsal, the bare form resolved and installed successfully, though Claude Code's own reference docs only demonstrate the explicit `@marketplace` form — treat the bare form as an observed convenience rather than a guaranteed contract).
+Alternatively, once the marketplace is added, the bare plugin name also works: `/plugin install agentic-framework`. The CLI reference documents `<plugin>` as "plugin name or `plugin-name@marketplace-name`", so the bare form is supported — but prefer the qualified form: it's unambiguous if another registered marketplace ever ships a plugin with the same name.
 
 **Windows MAX_PATH limit during marketplace clone:**
 On deeply nested Windows paths, marketplace clone fails with "Filename too long" at the 260-character limit. **Remediation:** enable Windows 10+ long paths in two steps (both required). First, run this PowerShell command as Administrator:
@@ -421,7 +421,7 @@ Then configure Git for long paths:
 ```bash
 git config --global core.longpaths true
 ```
-Restart Claude Code. Without both steps, the "Filename too long" error will recur.
+Restart Claude Code, then re-run the marketplace add and install from *Plugin installation failed* above. Without both steps, the "Filename too long" error will recur.
 
 **Running the shell test suites or validators manually on Windows:**
 If you are running the test suites manually on Windows, use the Git Bash bash.exe directly (not WSL's bash, which may be on PATH by default): `C:\Program Files\Git\bin\bash.exe -c 'bash tests/hooks.test.sh'`. Bare `bash` without a full path may resolve to WSL bash, which will fail or behave incorrectly.

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ When Git Bash is not installed, the hook chain's `sh` command fails with a "not 
 ```
 
 **Marketplace name suffix vs. GitHub path:**
-When installing a plugin, use the full `<name>@<marketplace>` form where `<marketplace>` is the marketplace's **registered name** (the `"name"` field in `.claude-plugin/marketplace.json` — for this repo, `claude-agentic-framework`).
+When installing a plugin, use the full `<name>@<marketplace>` form where `<marketplace>` is the marketplace's **registered name** (the `"name"` field in `.claude-plugin/marketplace.json` — for this repo, `claude-agentic-framework`), **not** the GitHub `owner/repo` path used with `/plugin marketplace add`.
 ```
 /plugin install agentic-framework@claude-agentic-framework
 ```

--- a/README.md
+++ b/README.md
@@ -406,10 +406,22 @@ When Git Bash is not installed, the hook chain's `sh` command fails with a "not 
 ```
 
 **Marketplace name suffix vs. GitHub path:**
-When installing a plugin using the full `<name>@<marketplace>` syntax, `<marketplace>` must be the marketplace's **registered name** (the `"name"` field in `.claude-plugin/marketplace.json` — for this repo, that's `claude-agentic-framework`), **not** the GitHub `owner/repo` path used with `/plugin marketplace add`. Verify the registered name with `/plugin marketplace list` or `claude plugin marketplace list`. **Simpler alternative:** once the marketplace is added, use the bare plugin name without the suffix: `/plugin install agentic-framework` — this resolves unambiguously and avoids the suffix confusion entirely.
+When installing a plugin, use the full `<name>@<marketplace>` form where `<marketplace>` is the marketplace's **registered name** (the `"name"` field in `.claude-plugin/marketplace.json` — for this repo, `claude-agentic-framework`).
+```
+/plugin install agentic-framework@claude-agentic-framework
+```
+Alternatively, once the marketplace is added, the bare plugin name also works: `/plugin install agentic-framework` (in this rehearsal, the bare form resolved and installed successfully, though Claude Code's own reference docs only demonstrate the explicit `@marketplace` form — treat the bare form as an observed convenience rather than a guaranteed contract).
 
 **Windows MAX_PATH limit during marketplace clone:**
-On Windows, if your Claude Code config directory resides under a deeply nested path (common with corporate-managed profiles, nested OneDrive-synced directories, or domain user AppData), the marketplace git clone can fail with a "Filename too long" error once combined with `.git/hooks/*.sample` internal paths, hitting the classic 260-character MAX_PATH limit. This is an environment constraint, not a defect in this repo (all repo paths are well under the limit). **Remediation:** enable the Windows 10+ long path support policy: run `regedit` or Group Policy Editor and set `HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` to `1` (requires administrator access), then restart Claude Code. Alternatively, if your IT policy permits, configure a shorter path for your Claude Code config directory (e.g., `C:\claude`).
+On deeply nested Windows paths, marketplace clone fails with "Filename too long" at the 260-character limit. **Remediation:** enable Windows 10+ long paths in two steps (both required). First, run this PowerShell command as Administrator:
+```powershell
+Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' LongPathsEnabled 1 -Type DWord
+```
+Then configure Git for long paths:
+```bash
+git config --global core.longpaths true
+```
+Restart Claude Code. Without both steps, the "Filename too long" error will recur.
 
 **Running the shell test suites or validators manually on Windows:**
 If you are running the test suites manually on Windows, use the Git Bash bash.exe directly (not WSL's bash, which may be on PATH by default): `C:\Program Files\Git\bin\bash.exe -c 'bash tests/hooks.test.sh'`. Bare `bash` without a full path may resolve to WSL bash, which will fail or behave incorrectly.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ When Git Bash is not installed, the hook chain's `sh` command fails with a "not 
 /plugin install agentic-framework@claude-agentic-framework     # Re-install
 ```
 
+**Marketplace name suffix vs. GitHub path:**
+When installing a plugin using the full `<name>@<marketplace>` syntax, `<marketplace>` must be the marketplace's **registered name** (the `"name"` field in `.claude-plugin/marketplace.json` — for this repo, that's `claude-agentic-framework`), **not** the GitHub `owner/repo` path used with `/plugin marketplace add`. Verify the registered name with `/plugin marketplace list` or `claude plugin marketplace list`. **Simpler alternative:** once the marketplace is added, use the bare plugin name without the suffix: `/plugin install agentic-framework` — this resolves unambiguously and avoids the suffix confusion entirely.
+
+**Windows MAX_PATH limit during marketplace clone:**
+On Windows, if your Claude Code config directory resides under a deeply nested path (common with corporate-managed profiles, nested OneDrive-synced directories, or domain user AppData), the marketplace git clone can fail with a "Filename too long" error once combined with `.git/hooks/*.sample` internal paths, hitting the classic 260-character MAX_PATH limit. This is an environment constraint, not a defect in this repo (all repo paths are well under the limit). **Remediation:** enable the Windows 10+ long path support policy: run `regedit` or Group Policy Editor and set `HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` to `1` (requires administrator access), then restart Claude Code. Alternatively, if your IT policy permits, configure a shorter path for your Claude Code config directory (e.g., `C:\claude`).
+
 **Running the shell test suites or validators manually on Windows:**
 If you are running the test suites manually on Windows, use the Git Bash bash.exe directly (not WSL's bash, which may be on PATH by default): `C:\Program Files\Git\bin\bash.exe -c 'bash tests/hooks.test.sh'`. Bare `bash` without a full path may resolve to WSL bash, which will fail or behave incorrectly.
 


### PR DESCRIPTION
## Summary
Two Troubleshooting entries added to README.md based on a live, isolated rehearsal of the real Claude Code plugin marketplace-add + install flow against this repo's actual pushed GitHub content - confirming the plugin pipeline (from #28) works end-to-end (both plugins install, all 21 agents/5 hooks/5 MCP servers load, plugin cache verifiably fresh from the real repo) while documenting two real user-facing gotchas found along the way:

- The `<name>@<marketplace>` install syntax needs the marketplace's registered name, not the GitHub owner/repo path used to add it.
- Windows users with deeply nested config paths can hit the 260-char MAX_PATH limit during the marketplace clone; documents the two-step fix (registry LongPathsEnabled + git core.longpaths).

No code or config files changed - prose only, and the underlying marketplace.json/plugin structure was independently verified correct during the rehearsal.

## Test plan
generate-docs.sh --check and validate-consistency.sh both green; code-review-gatekeeper APPROVED after two delta rounds (fixed an incomplete MAX_PATH remediation, removed an unconfirmed CLAUDE_CONFIG_DIR claim, scoped a bare-install-form claim to observed behavior rather than an unverifiable guarantee).