### PR TITLE
fix: add marketplace description and guard its agent count

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-agentic-framework",
+  "description": "Agent execution framework for Claude Code: 21 specialized agents with task routing, spec-driven build loops, and an enforced peer-review quality gate — shipped as a core plugin plus an optional MCP server bundle.",
   "owner": { "name": "Tomas Rampas", "url": "https://github.com/tomas-rampas" },
   "plugins": [
     {

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Validate plugin manifest (root)
         # A live spike confirmed `claude plugin validate` runs headless and
-        # unauthenticated in CI, exiting 0 in non-strict mode. --strict
-        # promotes warnings to errors and this repo currently carries known
-        # benign warnings, so the gate intentionally checks errors only
-        # rather than skipping manifest validation altogether.
+        # unauthenticated in CI, exiting 0 in non-strict mode. Errors-only
+        # is deliberate policy: the step above installs the latest
+        # @anthropic-ai/claude-code at run time, so a newly-introduced
+        # upstream warning class must not turn the build red.
         run: claude plugin validate .
 
       - name: Validate plugin manifest (mcp-plugin)

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -418,7 +418,9 @@ section "[8] Stated-count scan (README/docs headline counts == derived values)"
   # skills/<name>/SKILL.md layout only: legacy flat skills/*.md are excluded
   # (pending migration/removal, their internal narratives carry historical
   # numbers that are not current declarations). The marketplace manifest is
-  # included to guard the public plugin description against drift.
+  # scanned for agent counts: both the top-level .description (rule 8a: "N
+  # specialized agents") and per-plugin plugins[].description (rule 8g: "N-agent").
+  # Note that .claude-plugin/plugin.json and docs/ are NOT in scan_files.
   scan_files=()
   [[ -f "$ROOT/README.md" ]] && scan_files+=("$ROOT/README.md")
   [[ -f "$ROOT/.claude-plugin/marketplace.json" ]] && scan_files+=("$ROOT/.claude-plugin/marketplace.json")
@@ -458,6 +460,8 @@ section "[8] Stated-count scan (README/docs headline counts == derived values)"
         # Pull the full source line for context-based exclusions.
         srcline="$(sed -n "${lineno}p" "$f")"
         # Exclude grep-pattern contexts (detecting an old value, not stating one).
+        # NOTE: for single-line JSON prose (e.g., marketplace.json .description),
+        # a field containing the word "grep" in prose will silently bypass this check.
         if printf '%s' "$srcline" | grep -qE '\bgrep\b'; then
           continue
         fi
@@ -502,6 +506,9 @@ section "[8] Stated-count scan (README/docs headline counts == derived values)"
 
   # ---- 8f: "<N> commands" ----------------------------------------------------
   _scan_counts '[0-9]+ [Cc]ommands\b' first "$n_commands" "command count"
+
+  # ---- 8g: "<N>-agent" headline (the claude.json/plugin.json phrasing family) --
+  _scan_counts '[0-9]+-agent' first "$n_agents" "N-agent count"
 
   if [[ "$ok" -eq 1 ]]; then
     pass "all high-signal stated counts match derived values (agents=$n_agents, hooks=$n_hooks, skills=$n_skills, commands=$n_commands)"

--- a/scripts/validate-consistency.sh
+++ b/scripts/validate-consistency.sh
@@ -417,9 +417,11 @@ section "[8] Stated-count scan (README/docs headline counts == derived values)"
   # Files to scan for headline counts. Skills are scanned in the canonical
   # skills/<name>/SKILL.md layout only: legacy flat skills/*.md are excluded
   # (pending migration/removal, their internal narratives carry historical
-  # numbers that are not current declarations).
+  # numbers that are not current declarations). The marketplace manifest is
+  # included to guard the public plugin description against drift.
   scan_files=()
   [[ -f "$ROOT/README.md" ]] && scan_files+=("$ROOT/README.md")
+  [[ -f "$ROOT/.claude-plugin/marketplace.json" ]] && scan_files+=("$ROOT/.claude-plugin/marketplace.json")
   shopt -s nullglob
   for f in "$ROOT"/commands/*.md "$ROOT"/skills/*/SKILL.md; do scan_files+=("$f"); done
   shopt -u nullglob

--- a/tests/consistency.test.sh
+++ b/tests/consistency.test.sh
@@ -549,6 +549,38 @@ section "[20] Missing dispatch.sh: rm hooks/dispatch.sh -> non-zero (check 3)"
 }
 
 # ===========================================================================
+# CASE 21 - Drifted marketplace agent count: mutate marketplace.json
+#           plugins[0].description agent count -> check 8 must fail (rule 8g).
+# ===========================================================================
+section "[21] Drifted marketplace agent count: set to '99-agent' -> non-zero (check 8)"
+{
+  copy="$(make_copy)"
+  jq '.plugins[0].description = (.plugins[0].description | sub("[0-9]+-agent"; "99-agent"))' \
+    "$copy/.claude-plugin/marketplace.json" > "$copy/.claude-plugin/marketplace.json.tmp" \
+    && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when marketplace.json agent count drifts"
+  assert_out_contains "reports N-agent count mismatch in marketplace.json" "N-agent count: stated '99' != derived"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# CASE 22 - Drifted marketplace top-level description: mutate marketplace.json
+#           .description agent count -> check 8 must fail (rule 8a).
+# ===========================================================================
+section "[22] Drifted marketplace top-level description: set to '99 specialized agents' -> non-zero (check 8)"
+{
+  copy="$(make_copy)"
+  jq '.description = (.description | sub("[0-9]+ specialized"; "99 specialized"))' \
+    "$copy/.claude-plugin/marketplace.json" > "$copy/.claude-plugin/marketplace.json.tmp" \
+    && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
+  run_validate "$copy"
+  assert_rc_nonzero "validator fails when marketplace.json top-level description agent count drifts"
+  assert_out_contains "reports agent count mismatch in marketplace.json" "agent count: stated '99' != derived"
+  rm -rf "$copy"
+}
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 printf '\n%s================================================%s\n' "$C_CYN" "$C_NC"

--- a/tests/plugin-manifests.test.sh
+++ b/tests/plugin-manifests.test.sh
@@ -242,6 +242,22 @@ export FRAMEWORK_ROOT
   fi
 }
 
+# --- Assertion 6a: marketplace.json has a non-empty top-level description ---
+{
+  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
+  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
+  # Remove Windows line endings
+  desc="${desc//$'\r'/}"
+
+  if [[ "$desc_type" != "string" ]]; then
+    _fail "marketplace.json has a non-empty top-level .description" "type is $desc_type, not string"
+  elif [[ -n "$desc" && "$desc" != "null" && $desc =~ [^[:space:]] ]]; then
+    _pass "marketplace.json has a non-empty top-level .description"
+  else
+    _fail "marketplace.json has a non-empty top-level .description" "description was: $desc"
+  fi
+}
+
 # --- Assertion 7: hooks.json hook event names are valid ---
 {
   # Valid Claude Code hook events (from hookcheck.sh)
@@ -646,6 +662,56 @@ section "[RED-16] Remove dispatch.sh (should fail dispatch presence check)"
     _pass "RED-16: validator fails with missing-dispatch-sh when dispatch.sh is deleted"
   else
     _fail "RED-16: validator should fail with missing-dispatch-sh" "exit=$RUN_RC, output: $(printf '%s\n' "$RUN_OUT" | grep -E 'missing-dispatch-sh|check' || echo '(no matches)')"
+  fi
+
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# RED PATH CASE 17: Empty marketplace description (should fail Assertion 6a)
+# ===========================================================================
+section "[RED-17] Empty marketplace description (should fail non-empty check)"
+{
+  copy="$(make_copy)"
+  jq '.description = ""' "$copy/.claude-plugin/marketplace.json" \
+    > "$copy/.claude-plugin/marketplace.json.tmp" \
+    && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
+
+  # Re-run the assertion logic to verify it fails
+  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
+  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
+  desc="${desc//$'\r'/}"
+
+  # The assertion should fail because description is empty
+  if [[ "$desc_type" == "string" && -z "$desc" ]]; then
+    _pass "RED-17: empty description correctly fails the non-empty check"
+  else
+    _fail "RED-17: empty description should fail" "type=$desc_type, desc='$desc'"
+  fi
+
+  rm -rf "$copy"
+}
+
+# ===========================================================================
+# RED PATH CASE 18: Non-string marketplace description (should fail type check)
+# ===========================================================================
+section "[RED-18] Non-string marketplace description (should fail type check)"
+{
+  copy="$(make_copy)"
+  jq '.description = 42' "$copy/.claude-plugin/marketplace.json" \
+    > "$copy/.claude-plugin/marketplace.json.tmp" \
+    && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
+
+  # Re-run the assertion logic to verify it fails on type check
+  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
+  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
+  desc="${desc//$'\r'/}"
+
+  # The assertion should fail because description is not a string
+  if [[ "$desc_type" != "string" ]]; then
+    _pass "RED-18: numeric description correctly fails the type check"
+  else
+    _fail "RED-18: numeric description should fail type check" "type=$desc_type, desc='$desc'"
   fi
 
   rm -rf "$copy"

--- a/tests/plugin-manifests.test.sh
+++ b/tests/plugin-manifests.test.sh
@@ -115,6 +115,14 @@ assert_json_field_matches() {
   fi
 }
 
+_desc_is_valid() {           # <manifest> -> 0 iff .description is a non-blank string
+  local f="$1" t d
+  t="$(jq -r '.description | type' "$f" 2>/dev/null)" || return 1
+  [[ "$t" == "string" ]] || return 1
+  d="$(jq -r '.description' "$f")"; d="${d//$'\r'/}"
+  [[ $d =~ [^[:space:]] ]]
+}
+
 section() { printf '\n%s%s%s\n' "$C_CYN" "$1" "$C_NC"; }
 
 # --- validator helper -------------------------------------------------------
@@ -244,17 +252,10 @@ export FRAMEWORK_ROOT
 
 # --- Assertion 6a: marketplace.json has a non-empty top-level description ---
 {
-  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
-  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
-  # Remove Windows line endings
-  desc="${desc//$'\r'/}"
-
-  if [[ "$desc_type" != "string" ]]; then
-    _fail "marketplace.json has a non-empty top-level .description" "type is $desc_type, not string"
-  elif [[ -n "$desc" && "$desc" != "null" && $desc =~ [^[:space:]] ]]; then
+  if _desc_is_valid "$copy/.claude-plugin/marketplace.json"; then
     _pass "marketplace.json has a non-empty top-level .description"
   else
-    _fail "marketplace.json has a non-empty top-level .description" "description was: $desc"
+    _fail "marketplace.json has a non-empty top-level .description" "description is not a valid non-blank string"
   fi
 }
 
@@ -677,16 +678,11 @@ section "[RED-17] Empty marketplace description (should fail non-empty check)"
     > "$copy/.claude-plugin/marketplace.json.tmp" \
     && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
 
-  # Re-run the assertion logic to verify it fails
-  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
-  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
-  desc="${desc//$'\r'/}"
-
-  # The assertion should fail because description is empty
-  if [[ "$desc_type" == "string" && -z "$desc" ]]; then
-    _pass "RED-17: empty description correctly fails the non-empty check"
+  # Verify the helper catches empty description
+  if _desc_is_valid "$copy/.claude-plugin/marketplace.json"; then
+    _fail "RED-17: empty description should fail" "but helper returned success"
   else
-    _fail "RED-17: empty description should fail" "type=$desc_type, desc='$desc'"
+    _pass "RED-17: empty description correctly fails the non-empty check"
   fi
 
   rm -rf "$copy"
@@ -702,16 +698,11 @@ section "[RED-18] Non-string marketplace description (should fail type check)"
     > "$copy/.claude-plugin/marketplace.json.tmp" \
     && mv "$copy/.claude-plugin/marketplace.json.tmp" "$copy/.claude-plugin/marketplace.json"
 
-  # Re-run the assertion logic to verify it fails on type check
-  desc_type="$(jq -r '.description | type' "$copy/.claude-plugin/marketplace.json")"
-  desc="$(jq -r '.description' "$copy/.claude-plugin/marketplace.json")"
-  desc="${desc//$'\r'/}"
-
-  # The assertion should fail because description is not a string
-  if [[ "$desc_type" != "string" ]]; then
-    _pass "RED-18: numeric description correctly fails the type check"
+  # Verify the helper catches non-string description
+  if _desc_is_valid "$copy/.claude-plugin/marketplace.json"; then
+    _fail "RED-18: numeric description should fail" "but helper returned success"
   else
-    _fail "RED-18: numeric description should fail type check" "type=$desc_type, desc='$desc'"
+    _pass "RED-18: numeric description correctly fails the type check"
   fi
 
   rm -rf "$copy"


### PR DESCRIPTION
Fixes the `claude plugin validate .` warning "No marketplace description provided" by adding a top-level `description` to `.claude-plugin/marketplace.json`. Validation is now clean: 0 warnings, 0 errors, including under `--strict`.

The description states an agent count, so the manifest is wired into the repo's anti-drift machinery rather than leaving a hardcoded number unguarded:

- `scripts/validate-consistency.sh` scans the manifest for stated counts (rule 8a for the top-level `.description`, rule 8g for `plugins[].description`).
- `tests/consistency.test.sh` CASE 21 and CASE 22 prove the guard bites: drift the count and the validator fails; remove the wiring line and the same drift passes.
- `tests/plugin-manifests.test.sh` Assertion 6a rejects a missing, null, empty, whitespace-only or non-string description, with RED cases 17 and 18 sharing its predicate.

Verified locally: consistency 54/54, plugin-manifests 34/34, validate-consistency 13/13 (0 warnings), shellcheck clean.
