### PR TITLE
fix: quote argument-hint so migrate-legacy's frontmatter parses

### DIFF
--- a/commands/migrate-legacy.md
+++ b/commands/migrate-legacy.md
@@ -1,6 +1,6 @@
 ---
 description: Migrate legacy framework installs to the plugin pipeline
-argument-hint: <optional: any arguments to pass to the migration script>
+argument-hint: "<optional: any arguments to pass to the migration script>"
 ---
 
 Framework root: `${CLAUDE_PLUGIN_ROOT}` (when running from a development checkout of the framework itself, this may be empty — then use the current directory if it contains `claude.json`). All framework file paths below are relative to that root.


### PR DESCRIPTION
`commands/migrate-legacy.md` carried an unquoted `argument-hint` whose value
contains a colon-space:

```yaml
argument-hint: <optional: any arguments to pass to the migration script>
```

YAML reads that as `argument-hint: <optional` and then hits a second mapping
indicator (`: any arguments...`) on the same line. The **whole frontmatter block
fails to parse**, so both `description` and `argument-hint` are silently dropped
and `/agentic-framework:migrate-legacy` loads with empty metadata — no
description in the command list. Quoting the value fixes it.

Why it went unnoticed: `claude plugin validate .` resolves `.` to the marketplace
manifest and never opens the command files. Validating the plugin manifest by
explicit path surfaces it (exit 1 before, exit 0 after).

A sweep of all 41 frontmatter files with `yq` and with the plugin validator, in
agreement, found this as the only genuine failure. Four other commands carry
unquoted `<...>` in `argument-hint` and parse clean today because none contains a
colon-space or comma — fragile but not broken, and deliberately left alone.

Verified on this branch after rebase onto `d5b06a8`:

- `scripts/validate-consistency.sh` — exit 0, PASS, 0 blocking failures, 0 warnings
- `tests/plugin-manifests.test.sh` — exit 0, 34/34 assertions passed

Suites not run: the hooks and migrate batteries. This change touches one YAML
scalar in a command file and nothing else — no hook script, no migration path.
